### PR TITLE
fix: build:docker should not require host-side deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_ENV=production bun src/main.ts",
     "typecheck": "bun --check src/main.ts",
     "build": "rm -rf ./dist && bun build ./src/main.ts --target=bun --outdir=dist --minify",
-    "build:docker": "bun run build && docker build -t uartnode .",
+    "build:docker": "docker build -t uartnode .",
     "run:docker": "docker stop uartnode 2>/dev/null; docker rm uartnode 2>/dev/null; docker run -itd --name uartnode --restart always --init -p 9000:9000 -e NODE_TOKEN=$NODE_TOKEN uartnode"
   },
   "dependencies": {


### PR DESCRIPTION
## 问题

PR #2 merge 之后，部署机 `/home/cc/Web/uart-node` 跑 `npm run build:docker` 报：

```
1 | import socketClient from "socket.io-client";
                             ^
error: Could not resolve: "socket.io-client". Maybe you need to "bun install"?
    at /home/cc/Web/uart-node/src/IO.ts:1:26
error: script "build" exited with code 1
```

## 根因

PR #2 的 `package.json` 把 `build:docker` 写成了：

```json
"build:docker": "bun run build && docker build -t uartnode ."
```

`bun run build` 在 **host 机器**跑，要求 host 装过依赖（`bun install`）。
部署机 `node_modules` 是 pnpm 时代装的旧树（或压根没装），`bun run build` 失败，
根本到不了 `docker build` 那一步。

但 `Dockerfile` 自己就是 builder — `bun install --frozen-lockfile` + `bun build` 都在
容器内完成，**host 根本不需要装依赖**。原 `build:docker` 写法是多余的 host-side
pre-build，违背了 Docker 镜像自包含原则。

## 修复

```diff
- "build:docker": "bun run build && docker build -t uartnode ."
+ "build:docker": "docker build -t uartnode ."
```

部署机直接 `npm run build:docker` 即可，不依赖 host 装 deps。