### PR TITLE
fix: build:docker should not require host-side deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,12 @@ dist
 dist-test
 **/*.ts
 !src/**/*.ts
-types
 Dockerfile
-tsconfig.json
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+# 注：以下文件不能 ignore — Dockerfile builder 阶段 bun build 要用：
+#   tsconfig.json: 读 paths / module / moduleResolution / ignoreDeprecations
+#   types/:         tsconfig paths 映射的 .d.ts（types/uart.d.ts 兜底 import from "uart"）
+# 之前是直接抄 uart-pesiv-node 的 .dockerignore 模板，那边是 bun build --compile 单文件
+# 不需要 tsconfig；UartNode 走容器内 bun build 路径，必须带这两个进 context。

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_ENV=production bun src/main.ts",
     "typecheck": "bun --check src/main.ts",
     "build": "rm -rf ./dist && bun build ./src/main.ts --target=bun --outdir=dist --minify",
-    "build:docker": "bun run build && docker build -t uartnode .",
+    "build:docker": "docker build -t uartnode .",
     "run:docker": "docker stop uartnode 2>/dev/null; docker rm uartnode 2>/dev/null; docker run -itd --name uartnode --restart always --init -p 9000:9000 -e NODE_TOKEN=$NODE_TOKEN uartnode"
   },
   "dependencies": {


### PR DESCRIPTION
之前 PR #2 的 package.json 写的是 "bun run build && docker build -t uartnode ." 导致 host 机器必须先 bun install 装过依赖才能跑 build:docker — 部署机 (/home/cc/Web/uart-node) 没装 deps 时 docker build 前的 bun run build 直接炸 ("Could not resolve: socket.io-client")。

Dockerfile 自己就是 builder，bun install + bun build 都在容器内完成， host 只需要 docker + npm/bun 来触发 script，不该有 bun run build 这种 host-side pre-build。

改为: "docker build -t uartnode ."

修复后部署机直接 npm run build:docker 即可。