### PR TITLE
fix: config.ts 全 env 驱动，修 bun build DCE 砍 prod 分支的 bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@
 
 - **NODE_TOKEN 绝对不能写进 Dockerfile ARG/ENV** — 会进镜像层泄漏到 registry。
   必须运行时注入：`docker run -e NODE_TOKEN=...` 或 k8s secret。
+- **全 env 驱动**（与 `uart-pesiv-node` 对齐）：`IO_URI` / `IO_PATH` / `SERVER_URL` / `NODE_TOKEN`
+  都从 `process.env` 读，**不要**在 config.ts 里加 `isProd` / `NODE_ENV` 模式判断 —
+  bun build --minify 会 DCE 掉被求值的 prod 分支，运行时永远走 dev fallback。
+  容器里跑 prod host 一定要 `IO_URI=...` 显式注入。
 
 ## 未回归的运行时风险
 

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -1,18 +1,18 @@
 import socketClient from "socket.io-client";
-import config, { NODE_TOKEN } from "./config";
+import { IO_CONFIG, NODE_TOKEN } from "./config";
 
 /**
  * 连接到uartServer的IO对象
  */
-console.log(`连接socket服务器:${config.ServerHost}`);
+console.log(`连接socket服务器:${IO_CONFIG.uri}`);
 
 // PR #20 鉴权：Socket.IO 握手三通道（与 uart-pesiv-node io-client.ts 对齐）
 // - auth.token:    推荐通道，websocket 握手也能用
 // - query.token:   备选通道，server 端 ?token= 也认
 // - extraHeaders:  polling 通道用，握手阶段的 x-node-token header
 // - transportOptions: 4.5+ 修复了 websocket 阶段 extraHeaders 失效的 bug，4.7.5 已经默认带
-const IOClient = socketClient(config.ServerHost + '/node', {
-    path: "/client",
+const IOClient = socketClient(IO_CONFIG.uri, {
+    path: IO_CONFIG.path,
     auth: NODE_TOKEN ? { token: NODE_TOKEN } : undefined,
     query: NODE_TOKEN ? { token: NODE_TOKEN } : undefined,
     extraHeaders: NODE_TOKEN ? { 'x-node-token': NODE_TOKEN } : undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,36 @@
-const isProd = process.env.NODE_ENV === "production";
+/**
+ * 全局配置 — 全 env 驱动
+ *
+ * 跟 uart-pesiv-node/src/config.ts 风格对齐：
+ *   - process.env.X ?? 'default'  模式
+ *   - 不引入 isProd / NODE_ENV 等"环境模式"判断（那是 bun build DCE 的雷区）
+ *   - dev fallback 是 localhost:9010
+ *
+ * Bun 会自动注入 process.env，container 启动时通过 -e 或 docker-compose env 注入即可。
+ * Dockerfile 不写 ARG/ENV 注入任何敏感值（如 NODE_TOKEN），会进镜像层。
+ */
 
-const server = process.env.TEST_SERVER_HOST || "http://localhost:9010"
+/**
+ * Socket.IO 客户端配置
+ * - uri:  完整 ws url（含 namespace）
+ * - path: socket.io endpoint path（server 端挂在 /client）
+ */
+export const IO_CONFIG = {
+  uri: process.env.IO_URI ?? 'http://localhost:9010/node',
+  path: process.env.IO_PATH ?? '/client'
+} as const
+
+/**
+ * HTTP /api/node/* 上传基础 URL（fetch.ts 用）
+ */
+export const SERVER_URL: string = process.env.SERVER_URL ?? 'http://localhost:9010/api/node/'
 
 /**
  * Node 身份令牌（明文）
  *
  * 对应 uart-server PR #20 (feat(node-auth)) 鉴权：
  * - Socket.IO 握手走 auth.token / query.token / x-node-token header 三通道
- * - HTTP /api/node/* 走 x-node-token header（axios 改原生 fetch 后注入）
+ * - HTTP /api/node/* 走 x-node-token header（fetch.ts 注入）
  * - 部署流程：server 端先合 PR #20 -> admin rotate-token 拿明文 -> 写进 Node 的 NODE_TOKEN env
  *
  * 没设 NODE_TOKEN 时只 warn 不中断（与 uart-pesiv-node 行为一致），
@@ -24,63 +47,46 @@ if (!NODE_TOKEN) {
 }
 
 export default {
-  /**
-   * uartServer地址,用于socket连接
-   */
-  ServerHost: isProd ? "http://uart.ladishb.com:9010" : server,
-  /**
-   * uartServerApi地址,用于发送查询结果数据和节点运行数据
-   */
-  ServerApi: isProd ? "https://uart.ladishb.com/api/node/" : server+"/api/node/",
+  /** Socket.IO 配置 */
+  IO: IO_CONFIG,
+  /** HTTP 上行基础 URL */
+  ServerApi: SERVER_URL,
   ApiPath: {
-    uart: "/UartData",
-    runNode: "/RunData",
+    uart: '/UartData',
+    runNode: '/RunData'
   },
   EVENT_TCP: {
-    terminalOn: "terminalOn", // 终端设备上线
-    terminalOff: "terminalOff", // 终端设备下线
-    terminalMountDevTimeOut: "terminalMountDevTimeOut", // 设备挂载节点查询超时
-    terminalMountDevTimeOutRestore: "terminalMountDevTimeOutRestore", // 设备挂载节点查询超时
-    instructOprate: 'instructOprate', // 协议操作指令
-    instructTimeOut: 'instructTimeOut', // 设备指令超时
-
+    terminalOn: 'terminalOn',
+    terminalOff: 'terminalOff',
+    terminalMountDevTimeOut: 'terminalMountDevTimeOut',
+    terminalMountDevTimeOutRestore: 'terminalMountDevTimeOutRestore',
+    instructOprate: 'instructOprate',
+    instructTimeOut: 'instructTimeOut'
   },
   EVENT_SOCKET: {
-    register: "register", // 节点注册
-    registerSuccess: "registerSuccess", // 节点注册成功
-    query: "query", // 服务器查询请求
-    ready: "ready", // 启动Tcp服务成功
-    startError: "startError", // 启动Tcp服务出错
-    alarm: "alarm", // 节点告警事件
+    register: 'register',
+    registerSuccess: 'registerSuccess',
+    query: 'query',
+    ready: 'ready',
+    startError: 'startError',
+    alarm: 'alarm'
   },
   EVENT_SERVER: {
-    instructQuery: "instructQuery", // 操作设备状态指令
-    'DTUoprate': 'DTUoprate' // DTU AT指令
+    instructQuery: 'instructQuery',
+    DTUoprate: 'DTUoprate'
   },
-  /**
-   * 监听ip
-   */
-  localhost: "0.0.0.0",
-  /**
-   * 监听端口
-   */
+  /** 监听 ip */
+  localhost: '0.0.0.0',
+  /** 监听端口 */
   localport: 9000,
-  /**
-   * dtu连接超时
-   */
+  /** dtu 连接超时 */
   timeOut: 1000 * 60 * 5,
-  /**
-   * dtu查询超时
-   */
+  /** dtu 查询超时 */
   queryTimeOut: 1500,
-  /**
-   * dtu查询超时次数
-   */
+  /** dtu 查询超时次数 */
   queryTimeOutNum: 10,
-  /**
-   * dtu查询超时重启时间
-   */
+  /** dtu 查询超时重启时间 */
   queryTimeOutReload: 1000 * 60,
-  // 记录在线设备数
+  /** 在线设备数（运行时累加） */
   count: 0
-};
+}

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,5 @@
 import { queryOkUp, type nodeInfo } from "uart"
-import config, { NODE_TOKEN } from "./config"
+import { NODE_TOKEN, SERVER_URL } from "./config"
 
 // 兼容旧代码 namespace Uart.Terminal 写法（types-uart 包里是 namespace）
 // 项目自带的 types/uart.d.ts 没有 Uart namespace alias，
@@ -46,7 +46,7 @@ class Fetch {
         if (NODE_TOKEN) headers['x-node-token'] = NODE_TOKEN
 
         try {
-            const res = await fetch(config.ServerApi + path, {
+            const res = await fetch(SERVER_URL + path, {
                 method: 'POST',
                 headers,
                 body: JSON.stringify(data),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import config from "./config"
+import config, { IO_CONFIG } from "./config"
 import { registerConfig, queryObjectServer, instructQuery, DTUoprate } from "uart"
 import IOClient from "./IO"
 import TcpServer from "./TcpServer"
@@ -10,8 +10,8 @@ let tcpServer: TcpServer
 IOClient
     // 连接成功,触发node注册,发送node信息
     .on("connect", () => {
-        console.log(`${new Date().toLocaleString()}:已连接到UartServer:${config.ServerHost},socketID:${IOClient.id},`);
-        console.log(`已连接到UartServer:${config.ServerHost},socketID:${IOClient.id},`);
+        console.log(`${new Date().toLocaleString()}:已连接到UartServer:${IO_CONFIG.uri},socketID:${IOClient.id},`);
+        console.log(`已连接到UartServer:${IO_CONFIG.uri},socketID:${IOClient.id},`);
     })
     .on("accont", () => {
         IOClient.emit("register", tool.NodeInfo());


### PR DESCRIPTION
## 问题

PR #2 部署到 uart.ladishb.com 后，容器内 main 进程连不上 server，
`docker logs` 一直 `connect_error: xhr poll error` 循环重试。

## 根因

`config.ts` 顶层：

```ts
const isProd = process.env.NODE_ENV === "production"
// ...
ServerHost: isProd ? "http://uart.ladishb.com:9010" : server
```

bun build `--minify` 会做**静态求值 + DCE**：

1. build 时 host 上 `process.env.NODE_ENV` 是 undefined → `isProd` 静态求值为 `false`
2. 三元里的 prod 分支被 DCE 砍掉
3. 运行时 `ServerHost` 永远 = dev fallback (`http://localhost:9010`)
4. 容器内 `NODE_ENV=production` 也不会改变这个行为

**实测**：IIFE 包 `(() => process.env...)()` 也无效，bun minifier 太聪明会静态求值。

## 排查路径

SSH 进部署机后，容器内用 `bun -e 'await import("socket.io-client")...'` 最小复现**能连上** server，证明：
- token 鉴权没问题
- path `/client` 没问题
- 网络可达

进一步抓 `dist/main.js` 内容发现 — 产物里**只有 `localhost:9010`、没有 `uart.ladishb.com`**，确认了 DCE 假设。

## 修法

彻底干掉 `isProd` 模式判断，**全 env 驱动**（跟 `uart-pesiv-node/src/config.ts` 对齐）：

```ts
export const IO_CONFIG = {
  uri: process.env.IO_URI ?? 'http://localhost:9010/node',
  path: process.env.IO_PATH ?? '/client'
} as const

export const SERVER_URL: string =
  process.env.SERVER_URL ?? 'http://localhost:9010/api/node/'
```

每个值都是 `process.env.X` 的直接读取，minifier 砍不到，runtime 行为跟 env 注入完全一致。

## 改的文件

- `config.ts` — 重写，去 isProd hack + ServerHost/ServerApi 写死，引入 `IO_CONFIG` / `SERVER_URL` named export
- `IO.ts` — 用 `IO_CONFIG.uri` / `IO_CONFIG.path` 替代 `config.ServerHost + '/node'` + 硬编 `/client`
- `fetch.ts` — 用 `SERVER_URL` 替代 `config.ServerApi`
- `main.ts` — connect 日志用 `IO_CONFIG.uri` 替代 `config.ServerHost`
- `AGENTS.md` — 部署约束加"全 env 驱动，不要 isProd 模式判断"

## 验证

- ✅ `bun x tsc --noEmit -p tsconfig.json` 全绿
- ✅ bun build `--minify` 产物 78.39KB（跟之前体积一致）
- ✅ 跑 minify 后的产物：没设 env → `连接socket服务器:http://localhost:9010/node`（dev fallback）
- ✅ 设 `IO_URI=http://uart.ladishb.com:9010/node` → `连接socket服务器:http://uart.ladishb.com:9010/node`（env 生效）
- ✅ 实际拿到 `socketID` 连上 server，握手成功

## 部署

容器 env 必须显式设：

```bash
IO_URI=http://uart.ladishb.com:9010/node
SERVER_URL=https://uart.ladishb.com/api/node/
NODE_TOKEN=<plainToken from admin rotate-token>
```

`IO_URI` / `SERVER_URL` 容器里已经在了（跟 `uart-pesiv-node` 命名一致），merge 这个 PR 之后重启容器就行。