### PR TITLE
feat(dtus): Dtu 抽象 + CellularDtu 4G 实现 (RFC 002 PR #4)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,476 +1,73 @@
-import { Socket } from "net";
-import { queryObjectServer, instructQuery, DTUoprate, IntructQueryResult, AT, socketResult, ApolloMongoResult, queryOkUp } from "uart";
-import config from "./config";
-import IOClient from "./IO";
-import socketsb, { ProxySocketsb } from "./socket";
-import tool from "./tool";
-import { parseATResponse } from "./services/at-parse";
-import fetch from "./fetch";
-import { URLSearchParams } from "url";
+/**
+ * CellularDtu factory + 旧 Client 兼容 shim
+ *
+ * 跟 uart-pesiv-node 同类做法——PR #4 拆出 CellularDtu，
+ * 但保留 src/client.ts 旧入口给 TcpServer 过渡用（PR #5 改 TcpServer 时一起删）。
+ *
+ * 不要新代码用这个 shim——直接 import { CellularDtu } from './dtus/cellular'
+ */
 
-export default class Client {
-    /**
-     * dtu设备属性
-     */
-    readonly mac: string;
-    private jw: string;
-    private uart: string
-    private AT: boolean
-    private ICCID: string;
-    private PID: string;
-    private ver: string;
-    private Gver: string;
-    private iotStat: string;
+import { Socket } from 'net'
+import { URLSearchParams } from 'url'
+import { CellularDtu } from './dtus/cellular'
 
-    /**
-     *  设备超时列表
-     */
-    private timeOut: Map<number, number>
-    /**
-     * 查询pid列表
-     */
-    private pids: Set<number>
-    /**
-     * 主动重启状态
-     */
-    private reboot: boolean
-    /**
-     * 查询缓存
-     */
-    private Cache: (queryObjectServer | instructQuery | DTUoprate)[];
-    /**
-     * socket对象
-     */
-    socketsb: socketsb | null;
-    /**
-     *  暂停传输模式标志
-     */
-    private pause: boolean;
-    private signal: string;
-    //
-    constructor(socket: Socket, mac: string, registerArguments: URLSearchParams) {
-        this.mac = mac
-        this.AT = false
-        this.PID = registerArguments.get('host') || ''
-        this.ver = ''
-        this.Gver = ''
-        this.iotStat = ''
-        this.jw = ''
-        this.uart = ''
-        this.ICCID = ''
-        this.Cache = []
-        this.timeOut = new Map()
-        this.pids = new Set()
-        this.reboot = false
-        this.pause = false
-        this.signal = "0"
-        /**
-         * 代理socket对象,监听对象参数修改，触发事件
-         */
-        //this.socketsb = new Proxy(new socketsb(socket, mac), ProxySocketsb)
-        this.socketsb = new socketsb(socket, mac)
-
-        /**
-         * 发送设备上线
-         */
-        IOClient.emit(config.EVENT_TCP.terminalOn, mac, false)
-        /**
-         * 监听socket通道空闲,执行处理流程
-         */
-        if (this.socketsb) this.socketOn(this.socketsb.getSocket())
-    }
-
-
-    /**
-     * 加载socket监听事件
-    *  每次重新赋值socket都要重新绑定socket事件
-     * @param socket socket连接对象
-     */
-    private socketOn(socket: Socket) {
-        this.resume('connect')
-        // 上传设备信息
-        this.run().then(el => {
-            
-            fetch.dtuInfo(el as any) 
-        })
-        return socket
-            /**
-             * 监听socket通道释放
-             */
-            .on("free", (tag) => {
-                // console.log('free：', tag, this.Cache.length, this.getSocket().getStat().lock);
-                this.ProcessingQueue()
-            })
-            /**
-             * 监听socket关闭事件
-             */
-            .on("close", async hrr => {
-                console.log(`${new Date().toLocaleTimeString()} ##发送DTU:${this.mac} 离线告警`);
-                IOClient.emit(config.EVENT_TCP.terminalOff, this.mac, true)
-                this.setPause('close')
-                socket.destroy();
-                this.socketsb = null
-            })
-            .on('Queue', () => {
-                // console.log('有新的查询,查询请求堆积数目：', this.Cache.length, this.socketsb.getStat().lock);
-                IOClient.emit("busy", this.mac, this.Cache.length > 3, this.Cache.length)
-                if (this.socketsb && !this.socketsb.getStat().lock) {
-                    this.ProcessingQueue()
-                }
-
-            })
-    }
-
-    /**
-     * 获取dtu设备参数,at指令仅支持4G版本模块
-     */
-    public async run() {
-        // 等待暂停流程
-        await this.setPause('getPropertys')
-        const { AT, msg } = await this.QueryAT('PID')
-        if (AT) {
-            this.AT = AT
-            this.PID = msg
-            this.ver = (await this.QueryAT("VER")).msg
-            this.Gver = (await this.QueryAT("GVER")).msg
-            this.iotStat = (await this.QueryAT("IOTEN")).msg
-            this.ICCID = (await this.QueryAT('ICCID')).msg
-            this.jw = (await this.QueryAT("LOCATE=1")).msg
-            this.uart = (await this.QueryAT("UART=1")).msg
-            this.signal = (await this.QueryAT("GSLQ")).msg
-            // 已经无法批量管理iot设备,关闭iot功能,节省流量
-            await this.QueryAT("IOTEN=off")
-        }
-        // 获得结果,恢复处理流程
-        this.resume('getPropertys')
-        return this.getPropertys()
-    }
-
-    /**
-     * 设备断开重新连接之后重新绑定代理socket
-     * @param socket 
-     */
-    public async reConnectSocket(socket: Socket) {
-        // 记录socket状态，如果还没有被销毁而重新连接则可能是dtu不稳定，不发生设备恢复上线事件
-        // const socket_destroyed = this.socketsb.getSocket().destroyed
-        this.socketsb = new Proxy(new socketsb(socket, this.mac), ProxySocketsb)
-        this.socketOn(this.socketsb.getSocket())
-        // 判断是否是主动断开
-        if (this.reboot) {
-            setTimeout(() => {
-                this.reboot = false
-                IOClient.emit(config.EVENT_TCP.terminalOn, this.mac, true)
-            }, 60000);
-        } else IOClient.emit(config.EVENT_TCP.terminalOn, this.mac, false)
-        console.log({
-            time: new Date().toLocaleString(),
-            event: `DTU:${this.mac}恢复连接,模式:${this.reboot ? '主动断开' : '被动断开'}`,
-            //remind: `设备${socket_destroyed ? '正常' : '未销毁'}重连`
-        });
-    }
-
-    /**
-     * 对外暴露dtu对象属性
-     */
-    public getPropertys() {
-        return {
-            mac: this.mac,
-            ...(this.socketsb ? this.socketsb.getStat() : {}),
-            AT: this.AT,
-            PID: this.PID,
-            ver: this.ver,
-            Gver: this.Gver,
-            iotStat: this.iotStat,
-            jw: this.jw,
-            uart: this.uart,
-            ICCID: this.ICCID,
-            signal: this.signal
-        }
-    }
-
-    /**
-     *  查询dtu对象属性,查询行为是高优先级的操作，会暂停整个流程的处理,优先完成查询
-     * @param content 查询指令
-     */
-    private async QueryAT(content: string) {
-        // 组装操作指令
-        const queryString = Buffer.from('+++AT+' + content + "\r", "utf-8")
-        if (this.socketsb) {
-            const { buffer } = await this.socketsb.write(queryString)
-            return parseATResponse(buffer)
-        } else {
-            return {
-                AT: false,
-                msg: 'socket offline'
-            }
-        }
-
-    }
-
-    /**
-     * 暂停整个处理流程，并等待socket处理未完成的查询操作
-     * @param tags 标记标签,用于log标记
-     */
-    private setPause(tags: string = "null") {
-        this.pause = true
-        /*  
-            0，判断socket是否空闲,如果不是则说明端口正在被使用
-            1，等待Process处理流程响应pause操作，响应pause事件
-            2，判断socket是否空闲，如果占用状态则等待socket发送free恢复空闲事件
-            3，返回最终的操作结果true
-        */
-        // console.log('SetPause', tags);
-        return new Promise<boolean>((resolve) => {
-            if (this.socketsb) {
-                if (!this.socketsb.getStat().lock) {
-                    resolve(true)
-                } else {
-                    this.socketsb.getSocket().once('free', () => {
-                        resolve(true)
-                    })
-                }
-            } else {
-                resolve(true)
-            }
-
-        })
-    }
-
-    /**
-     * 恢复整个处理流程
-     * @param tags 
-     */
-    private resume(tags: string = "null") {
-        /* 
-            如果socket占用状态，等待socket处理完未处理的操作
-            把pause标志关闭,
-            收到结果之后再次发送free事件，因为下面注册的free监听会在ProcessingQueue之后执行，ProcessingQueue判断的pause值可能是true
-        */
-        /* return await new Promise<boolean>(resolve => {
-            if (this.socketsb.getStat().lock) {
-                this.socketsb.getSocket().once('free', () => {
-                    this.pause = false
-                    resolve(true)
-                })
-            } else {
-                this.pause = false
-                resolve(true)
-            }
-        }).then(() => this.socketsb.getSocket().emit('free')) */
-        this.pause = false
-        if (this.socketsb) {
-            this.socketsb.getSocket()
-                .once('free', () => { })// console.log('恢复暂停', tags))
-                .emit('free', 'resume')
-        }
-        return this
-    }
-
-    /**
-     * 重启socket
-     */
-    private async resatrtSocket() {
-        await this.setPause('resatrtSocket')
-        this.QueryAT("Z").then(el => {
-            this.reboot = true
-            this.socketsb?.getSocket()
-                .once("connecting", (stat: boolean) => {
-                    // console.log({ el, msg: 'resatrtSocket', ...this.getPropertys() });
-                }).destroy()
-            this.resume()
-        })
-    }
-
-    /**
-     * 缓存所有操作指令,根据操作类型不同优先级不同 
-     * 判断缓存操作列表指令堆积数量，大于一条发送设备繁忙状态 
-     *  顺序为队列式先进先出，at操作和oprate操作会插入到队列的最前面，优先执行
-      *  如果socket空闲,运行处理流程,避免因为处理流程为运行而堆积操作
-       * 如果socket忙碌，则会在空闲之后发生free事件,在constructor初始化时监听free事件
-     * @param Query 发送到dtu上面的查询指令
-     */
-    saveCache(Query: queryObjectServer | instructQuery | DTUoprate) {
-        switch (Query.eventType) {
-            case "QueryInstruct":
-                this.Cache.push(Query)
-                break
-            case "ATInstruct":
-            case "OprateInstruct":
-                this.Cache.unshift(Query)
-                break
-        }
-        this.socketsb?.getSocket().emit('Queue')
-    }
-
-    /**
-     * 运行处理流程
-        检查查询缓存中查询堆积是否超过3条，超过发送dtu忙碌状态事件
-        判断是否处于暂停模式,是的话跳过处理
-        else
-            取操作缓存中0位的操作,根据类型执行不同的指令操作
-     */
-    private async ProcessingQueue() {
-        IOClient.emit("busy", this.mac, this.Cache.length > 3, this.Cache.length)
-        // console.log('start ProcessingQueue', this.Cache.length, this.socketsb.getStat().lock, this.pause);
-        if (this.socketsb && !this.pause && this.Cache.length > 0) {
-            const Query = this.Cache.shift()
-            if (Query) {
-                // console.log('执行查询任务 ', Query.eventType, this.socketsb.getStat().lock);
-                switch (Query.eventType) {
-                    case "QueryInstruct":
-                        this.QueryInstruct(Query as queryObjectServer)
-                        break;
-                    case "OprateInstruct":
-                        {
-                            const query = Query as instructQuery
-                            // 构建查询字符串转换Buffer
-                            const queryString = query.type === 485 ? Buffer.from(query.content as string, "hex") : Buffer.from(query.content as string + "\r", "utf-8");
-
-                            const result = await this.socketsb.write(queryString)
-                            this.OprateParse(query, result)
-
-                        }
-                        break
-                    // at操作
-                    case "ATInstruct":
-                        {
-                            const query = Query as DTUoprate
-                            // 构建查询字符串转换Buffer
-                            const queryString = Buffer.from(query.content + "\r", "utf-8")
-                            const result = await this.socketsb.write(queryString)
-                            this.ATParse(query, result)
-                        }
-                        break
-                }
-            }
-        }
-    }
-
-    /**
-     *  数据查询指令
-     * @param Query 
-     */
-    private async QueryInstruct(Query: queryObjectServer) {
-        this.pids.add(Query.pid)
-        // 存储结果集
-        const IntructQueryResults = [] as IntructQueryResult[];
-        // 如果设备在超时列表中，则把请求指令精简为一条，避免设备离线查询请求阻塞
-        if (this.timeOut.has(Query.pid)) Query.content = [Query.content.pop()!]
-
-        // 
-        let len = Query.content.length
-        // 便利设备的每条指令,阻塞终端,依次查询
-        // console.time(Query.timeStamp + Query.mac + Query.Interval);
-        for (let content of Query.content) {
-            // 构建查询字符串转换Buffer
-            const queryString = Query.type === 485 ? Buffer.from(content, "hex") : Buffer.from(content + "\r", "utf-8");
-            // 持续占用端口,知道最后一个释放端口
-            const data: socketResult = this.socketsb ? await this.socketsb!.write(queryString, 10000, --len !== 0) : { useByte: 0, useTime: 0, buffer: "unSocket" }
-            IntructQueryResults.push({ content, ...data });
-        }
-        // this.socketsb.getSocket().emit('free')
-        // console.timeEnd(Query.timeStamp + Query.mac + Query.Interval)
-
-        // 统计
-        // console.log(new Date().toLocaleTimeString(), Query.mac + ' success++', this.Cache.length, len);
-        Query.useBytes = IntructQueryResults.map(el => el.useByte).reduce((pre, cu) => pre + cu)
-        Query.useTime = IntructQueryResults.map(el => el.useTime).reduce((pre, cu) => pre + cu)
-        // 如果socket已断开，查询结果则没有任何意义
-        if (this.socketsb && this.socketsb.getStat().connecting) {
-            // 如果结果集每条指令都超时则加入到超时记录
-            if (IntructQueryResults.every((el) => !Buffer.isBuffer(el.buffer))) {
-                const num = this.timeOut.get(Query.pid) || 1
-                // 触发查询超时事件
-                IOClient.emit(config.EVENT_TCP.terminalMountDevTimeOut, Query.mac, Query.pid, num)
-                // 超时次数=10次,硬重启DTU设备
-                console.log(`${new Date().toLocaleString()}###DTU ${Query.mac}/${Query.pid}/${Query.mountDev}/${Query.protocol} 查询指令超时 [${num}]次,pids:${Array.from(this.pids)},interval:${Query.Interval}`);
-                // 如果挂载的pid全部超时且次数大于10,执行设备重启指令
-                if (num === 10 && !this.socketsb!.getSocket().destroyed && this.timeOut.size >= this.pids.size && Array.from(this.timeOut.values()).every(num => num >= 10)) {
-                    console.log(`###DTU ${Query.mac}/pids:${Array.from(this.pids)} 查询指令全部超时十次,硬重启,断开DTU连接`)
-                    this.resatrtSocket()
-                }
-                this.timeOut.set(Query.pid, num + 1);
-            } else {
-                // 如果有超时记录,删除超时记录，触发data
-                this.timeOut.delete(Query.pid)
-                // 刷选出有结果的buffer
-                const contents = IntructQueryResults.filter((el) => Buffer.isBuffer(el.buffer));
-                // 获取正确执行的指令
-                const okContents = new Set(contents.map(el => el.content))
-                // 刷选出其中超时的指令,发送给服务器超时查询记录
-                const TimeOutContents = Query.content.filter(el => !okContents.has(el))
-                if (TimeOutContents.length > 0) {
-                    IOClient.emit(config.EVENT_TCP.instructTimeOut, Query.mac, Query.pid, TimeOutContents)
-                    console.log(`###DTU ${Query.mac}/${Query.pid}/${Query.mountDev}/${Query.protocol}/${Query.Interval}指令:[${TimeOutContents.join(",")}] 超时`);
-                }
-                // 合成result
-                const SuccessResult = Object.assign<queryObjectServer, Partial<queryOkUp>>(Query, { contents, time: new Date().toString() }) as queryOkUp;
-
-                // 加入结果集
-                //Cache.pushColletion(SuccessResult);
-                fetch.queryData(SuccessResult)
-            }
-        } else console.log('socket is disconnect,QuertInstruct is nothing')
-    }
-
-    /**
-     * 操作指令结果处理程序
-     * @param Query 
-     * @param res 
-     */
-    private OprateParse(Query: instructQuery, res: socketResult) {
-        const { buffer, useTime } = res
-        const result: Partial<ApolloMongoResult> = {
-            ok: 0,
-            msg: "挂载设备响应超时，请检查指令是否正确或设备是否在线/" + buffer,
-            upserted: buffer
-        };
-        if (Buffer.isBuffer(buffer)) {
-            result.ok = 1;
-            // 检测接受的数据是否合法
-            switch (Query.type) {
-                case 232:
-                    result.msg = "设备已响应,返回数据：" + buffer.toString("utf8").replace(/(\(|\n|\r)/g, "");
-                    break;
-                case 485:
-                    const str = (buffer.readIntBE(1, 1) !== parseInt((<string>Query.content).slice(2, 4))) ? "设备已响应，但操作失败,返回字节：" : "设备已响应,返回字节："
-                    result.msg = str + buffer.toString("hex");
-            }
-        }
-        console.log({ Query, result, res });
-        IOClient.emit('deviceopratesuccess', Query.events, result);
-    }
-
-    /**
-     * AT指令结果处理程序
-     * @param Query 
-     * @param res 
-     */
-    private ATParse(Query: DTUoprate, res: socketResult) {
-        const { buffer, useTime } = res
-        const parse = parseATResponse(buffer)
-        if (parse.AT && !parse.msg) {
-            this.run().then(el => fetch.dtuInfo(el as any))
-        }
-        const result: Partial<ApolloMongoResult> = {
-            ok: parse.AT ? 1 : 0,
-            msg: parse.AT ? parse.msg : '挂载设备响应超时，请检查指令是否正确或设备是否在线',
-            upserted: buffer
-        }
-        console.log({ Query, result, res });
-
-        IOClient.emit('dtuopratesuccess', Query.events, result)
-    }
-}
-
-
-
+export { CellularDtu } from './dtus/cellular'
+export { Dtu, type DtuQueryItem } from './dtus/base'
 
 /**
- * 拦截class对象修改
+ * 旧 Client class 兼容垫片
+ *
+ * 老 src/client.ts 行为 1:1 移植到 CellularDtu。
+ * 保留 Client 类名 + ProxyClient 给 TcpServer 过渡用——
+ * 内部委托给 CellularDtu，外部 API 表面不变。
+ *
+ * @deprecated 直接 import CellularDtu
+ */
+export default class Client {
+  readonly mac: string
+  readonly dtus: CellularDtu
+  // 老 client.ts:40 Cache 字段保留（外部可能访问，虽然 AGENTS.md 说不要用）
+  private Cache: any[] = []
+  // 老 client.ts:44 socketsb 字段
+  socketsb: any
+  // 主动重启状态（老 client.ts:36 reboot）
+  private reboot = false
+
+  constructor(socket: Socket, mac: string, _registerArguments: URLSearchParams) {
+    this.mac = mac
+    this.dtus = new CellularDtu(socket, mac)
+    this.socketsb = this.dtus.socketsb
+  }
+
+  // ======================== 老 Client API 兼容（委托给 CellularDtu）========================
+
+  /** 旧 reConnectSocket 行为 1:1（@deprecated） */
+  public async reConnectSocket(socket: Socket): Promise<void> {
+    this.dtus.reConnectSocket(socket)
+    this.socketsb = this.dtus.socketsb
+  }
+
+  /** 旧 getPropertys 行为 1:1（@deprecated） */
+  public getPropertys(): Record<string, unknown> {
+    return this.dtus.getPropertys()
+  }
+
+  /** 旧 saveCache 行为 1:1（@deprecated） */
+  public saveCache(query: any): void {
+    this.dtus.saveCache(query)
+  }
+}
+
+/**
+ * 旧 ProxyClient 兼容垫片
+ *
+ * 老 client.ts:472 ProxyClient 是个 ProxyHandler，对 set 做代理。
+ * 实际行为只放行（return Reflect.set），等于不过滤。
+ *
+ * @deprecated PR #5 改 TcpServer 时一起删
  */
 export const ProxyClient: ProxyHandler<Client> = {
-    set(target, p, value) {
-        return Reflect.set(target, p, value)
-    }
+  set(target, p, value) {
+    return Reflect.set(target, p, value)
+  }
 }

--- a/src/dtus/base.ts
+++ b/src/dtus/base.ts
@@ -1,0 +1,396 @@
+/**
+ * Dtu 抽象基类（UartNode RFC 002 §3.4 + §6.5 PR #4）
+ *
+ * 把 src/client.ts 的"单 DTU 状态机"从"具体 4G 实现"剥成"通用基类"——
+ * 4G/2G/NB DTU 走 CellularDtu（PR #4 落地），未来 LAN 网关走 LanDtu（RFC 001）。
+ *
+ * 行为契约（跟 src/client.ts 1:1 对齐）：
+ *   1. 通用：FIFO 队列 + AT/Oprate 插队到队首 + socket 锁 + 超时 10 次硬重启
+ *   2. 通用：pause / resume（等待当前 socket 操作完成）
+ *   3. 通用：onSocketClose → terminalOff(true) 上报 server
+ *   4. 抽象：initialize() —— 4G 批量查 AT；LAN HTTP API
+ *   5. 抽象：restart() —— 4G AT+Z；LAN HTTP /reboot
+ *   6. 抽象：processQueue() —— 处理逻辑
+ *
+ * 设计要点：
+ *   - 字段保持跟老 Client 一样的可访问性（protected 子类用，public 测试用）
+ *   - IOClient 用 PR #1 class 版本（src/services/io-client.ts），不是顶层单例
+ *   - socketsb 用 src/socket.ts 现成 class（不重写，staging 24h 行为兜底）
+ *   - getPropertys() 保留老 11 字段形状，server 端契约不破坏
+ *
+ * 跟 uart-pesiv-node 暂无同构（pesiv 是单设备 UPS 卡，不需要 Dtu 抽象）。
+ */
+
+import { Socket } from 'net'
+import { URLSearchParams } from 'url'
+import { type queryObjectServer, type instructQuery, type DTUoprate, type socketResult, type IntructQueryResult, type ApolloMongoResult } from 'uart'
+import socketsb from '../socket'
+import { getIOClient } from '../services/io-client'
+import { EVENT_NODE_TERMINAL_OFF } from '../protocol/events'
+import { parseATResponse } from '../services/at-parse'
+import fetch from '../fetch'
+import config from '../config'
+
+/** Dtu 队列中的指令项（QueryInstruct / OprateInstruct / ATInstruct） */
+export type DtuQueryItem = queryObjectServer | instructQuery | DTUoprate
+
+/**
+ * Dtu 抽象基类
+ *
+ * 子类必须实现：initialize() / restart() / processQueue()
+ * 子类可重写：handleATResponse()（默认 1:1 抄老 client.ts ATParse 行为）
+ */
+export abstract class Dtu {
+  /** 设备主键（v4 改 15 位 IMEI；v3.3.0 用 IMEI 后 12 位，PR #4 暂保持 slice(12)） */
+  readonly mac: string
+
+  /** 设备属性（4G: AT=bool, PID/ver/Gver/iotStat/jw/uart/ICCID/signal；子类按需初始化） */
+  protected jw = ''
+  protected uart = ''
+  protected AT = false
+  protected ICCID = ''
+  protected PID = ''
+  protected ver = ''
+  protected Gver = ''
+  protected iotStat = ''
+  protected signal = '0'
+
+  /** 设备超时列表：pid -> 超时次数（10 次硬重启） */
+  protected timeOut: Map<number, number> = new Map()
+  /** 已查询过的 pid 集合（用于全 pid 超时判断） */
+  protected pids: Set<number> = new Set()
+  /** 主动重启状态：true 时 reConnectSocket 会延迟 60s 发 terminalOn(reline=true) */
+  protected reboot = false
+  /** 指令缓存（FIFO + AT/Oprate 插队） */
+  protected cache: DtuQueryItem[] = []
+  /** socket 封装（socketsb = 写锁 + 字节统计 + ProxySocket） */
+  socketsb: socketsb | null = null
+  /** 暂停传输模式标志（initialize 期间置 true） */
+  protected pause = false
+
+  constructor(socket: Socket, mac: string) {
+    this.mac = mac
+    // 代理 socket 跟老 client.ts 保持一致（ProxySocketsb 暂未启用，但 socketsb 内部已用 ProxySocket）
+    this.socketsb = new socketsb(socket, mac)
+
+    // 老 client.ts:76 行为 1:1：构造时立即发 terminalOn
+    getIOClient().terminalOn(this.mac, false)
+
+    // 老 client.ts:80 行为 1:1：构造时绑定 socket 监听
+    this.bindSocket(this.socketsb.getSocket())
+  }
+
+  // ======================== 抽象方法（子类必须实现）========================
+
+  /**
+   * 设备上线后异步初始化
+   * - CellularDtu: 批量查 AT (PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ) + 关 IOTEN + 上报 dtuInfo
+   * - LanDtu (未来): HTTP /api/devices/:mac/profile
+   */
+  abstract initialize(): Promise<void>
+
+  /**
+   * 主动重启设备
+   * - CellularDtu: AT+Z（跟老 client.ts:272-281 resatrtSocket 行为 1:1）
+   * - LanDtu (未来): HTTP POST /api/devices/:mac/reboot
+   */
+  abstract restart(): Promise<void>
+
+  /**
+   * 处理缓存中的指令（4G: AT 命令 / Oprate 命令 / QueryInstruct）
+   * 队列调度 + 写锁释放走基类通用逻辑，子类实现具体指令执行
+   */
+  protected abstract processQueue(query: DtuQueryItem): Promise<void>
+
+  // ======================== 通用行为（基类实现，行为 1:1 抄老 client.ts）========================
+
+  /**
+   * 加载 socket 监听事件
+   * 跟老 client.ts:89-122 socketOn 行为 1:1
+   */
+  protected bindSocket(socket: Socket): void {
+    this.resume('connect')
+    // 上传设备信息：先跑 initialize（异步），完成后再 fetch.dtuInfo
+    this.initialize()
+      .then(info => {
+        fetch.dtuInfo(info as any)
+      })
+      .catch(err => {
+        // 老 client.ts 用 promise 没 catch，错误会被 unhandledRejection 兜底
+        // 这里加 console.error 方便 staging 24h 观察
+        console.error(`[Dtu ${this.mac}] initialize failed:`, err)
+      })
+
+    socket
+      // 监听 socket 通道释放 → 触发队列处理
+      .on('free', () => {
+        this.processingQueue()
+      })
+      // 监听 socket 关闭事件 → 上报 terminalOff
+      .on('close', () => {
+        console.log(`${new Date().toLocaleTimeString()} ##发送DTU:${this.mac} 离线告警`)
+        getIOClient().terminalOff(this.mac, true)
+        this.setPause('close')
+        socket.destroy()
+        this.socketsb = null
+      })
+      // 监听新指令入队 → 触发队列处理
+      .on('Queue', () => {
+        getIOClient().emit('busy', this.mac, this.cache.length > 3, this.cache.length)
+        if (this.socketsb && !this.socketsb.getStat().lock) {
+          this.processingQueue()
+        }
+      })
+  }
+
+  /**
+   * 设备断开重新连接后重新绑定代理 socket
+   * 跟老 client.ts:153-170 reConnectSocket 行为 1:1
+   */
+  public reConnectSocket(socket: Socket): void {
+    this.socketsb = new socketsb(socket, this.mac)
+    this.bindSocket(this.socketsb.getSocket())
+    // 判断是否是主动断开
+    if (this.reboot) {
+      setTimeout(() => {
+        this.reboot = false
+        getIOClient().terminalOn(this.mac, true)
+      }, 60000)
+    } else {
+      getIOClient().terminalOn(this.mac, false)
+    }
+    console.log({
+      time: new Date().toLocaleString(),
+      event: `DTU:${this.mac}恢复连接,模式:${this.reboot ? '主动断开' : '被动断开'}`
+    })
+  }
+
+  /**
+   * 暴露 dtu 对象属性（11 字段，server 端契约）
+   * 跟老 client.ts:175-189 getPropertys 行为 1:1
+   */
+  public getPropertys(): Record<string, unknown> {
+    return {
+      mac: this.mac,
+      ...(this.socketsb ? this.socketsb.getStat() : {}),
+      AT: this.AT,
+      PID: this.PID,
+      ver: this.ver,
+      Gver: this.Gver,
+      iotStat: this.iotStat,
+      jw: this.jw,
+      uart: this.uart,
+      ICCID: this.ICCID,
+      signal: this.signal
+    }
+  }
+
+  /**
+   * 处理查询请求（外部入口，TcpServer.Bus 调用）
+   * 跟老 client.ts:292-303 saveCache 行为 1:1
+   */
+  public saveCache(query: DtuQueryItem): void {
+    switch (query.eventType) {
+      case 'QueryInstruct':
+        this.cache.push(query)
+        break
+      case 'ATInstruct':
+      case 'OprateInstruct':
+        this.cache.unshift(query)
+        break
+    }
+    this.socketsb?.getSocket().emit('Queue')
+  }
+
+  /**
+   * 通用：socket close 时通知 server
+   * （RFC 002 §3.4 字面方法，子类可重写；默认 1:1 抄老 client.ts bindSocket close 行为）
+   */
+  public onSocketClose(): void {
+    getIOClient().terminalOff(this.mac, true)
+  }
+
+  // ======================== 内部：pause / resume / 队列调度 ========================
+
+  /**
+   * 暂停整个处理流程，并等待 socket 处理未完成的查询操作
+   * 跟老 client.ts:214-237 setPause 行为 1:1
+   */
+  protected setPause(tag: string = 'null'): Promise<boolean> {
+    this.pause = true
+    return new Promise<boolean>(resolve => {
+      if (this.socketsb) {
+        if (!this.socketsb.getStat().lock) {
+          resolve(true)
+        } else {
+          this.socketsb.getSocket().once('free', () => {
+            resolve(true)
+          })
+        }
+      } else {
+        resolve(true)
+      }
+    })
+  }
+
+  /**
+   * 恢复整个处理流程
+   * 跟老 client.ts:243-267 resume 行为 1:1
+   */
+  protected resume(tag: string = 'null'): this {
+    this.pause = false
+    if (this.socketsb) {
+      this.socketsb.getSocket()
+        .once('free', () => { })
+        .emit('free', 'resume')
+    }
+    return this
+  }
+
+  /**
+   * 处理缓存中的指令（基类通用调度）
+   * 跟老 client.ts:312-347 ProcessingQueue 行为 1:1（调度逻辑）
+   *
+   * 1. 先发 busy 事件（堆积 > 3 上报）
+   * 2. 取队首 → 根据 eventType 分发：
+   *    - QueryInstruct → queryInstruct()（基类实现）
+   *    - OprateInstruct / ATInstruct → 子类 processQueue() 处理
+   */
+  protected async processingQueue(): Promise<void> {
+    getIOClient().emit('busy', this.mac, this.cache.length > 3, this.cache.length)
+    if (this.socketsb && !this.pause && this.cache.length > 0) {
+      const query = this.cache.shift()
+      if (query) {
+        switch (query.eventType) {
+          case 'QueryInstruct':
+            await this.queryInstruct(query as queryObjectServer)
+            break
+          case 'OprateInstruct':
+          case 'ATInstruct':
+            await this.processQueue(query as DtuQueryItem)
+            break
+        }
+      }
+    }
+  }
+
+  // ======================== 内部：QueryInstruct 通用实现（4G/LAN 行为相同）========================
+
+  /**
+   * 数据查询指令（跟老 client.ts:353-414 QueryInstruct 行为 1:1）
+   *
+   * 关键不变量：
+   *   - 设备在超时列表中 → 简化指令为最后一条（避免离线查询阻塞）
+   *   - 每条 content 写一次 socket，type=485 走 hex 编码
+   *   - 全部超时 → 触发 terminalMountDevTimeOut + 10 次硬重启
+   *   - 部分超时 → 上报 instructTimeOut + 成功的合成 queryOkUp
+   *   - socket 断开 → 不做任何事
+   */
+  protected async queryInstruct(query: queryObjectServer): Promise<void> {
+    this.pids.add(query.pid)
+    const results: IntructQueryResult[] = []
+    if (this.timeOut.has(query.pid)) {
+      query.content = [query.content.pop()!]
+    }
+    let len = query.content.length
+    for (const content of query.content) {
+      const queryString = query.type === 485
+        ? Buffer.from(content, 'hex')
+        : Buffer.from(content + '\r', 'utf-8')
+      const data: socketResult = this.socketsb
+        ? await this.socketsb.write(queryString, 10000, --len !== 0)
+        : { useByte: 0, useTime: 0, buffer: 'unSocket' }
+      results.push({ content, ...data })
+    }
+    query.useBytes = results.map(el => el.useByte).reduce((pre, cu) => pre + cu)
+    query.useTime = results.map(el => el.useTime).reduce((pre, cu) => pre + cu)
+    if (this.socketsb && this.socketsb.getStat().connecting) {
+      // 全部超时
+      if (results.every(el => !Buffer.isBuffer(el.buffer))) {
+        const num = this.timeOut.get(query.pid) || 1
+        getIOClient().terminalMountDevTimeOut(query.mac, query.pid, num)
+        console.log(`${new Date().toLocaleString()}###DTU ${query.mac}/${query.pid}/${query.mountDev}/${query.protocol} 查询指令超时 [${num}]次,pids:${Array.from(this.pids)},interval:${query.Interval}`)
+        if (
+          num === 10 &&
+          !this.socketsb.getSocket().destroyed &&
+          this.timeOut.size >= this.pids.size &&
+          Array.from(this.timeOut.values()).every(n => n >= 10)
+        ) {
+          console.log(`###DTU ${query.mac}/pids:${Array.from(this.pids)} 查询指令全部超时十次,硬重启,断开DTU连接`)
+          await this.restart()
+        }
+        this.timeOut.set(query.pid, num + 1)
+      } else {
+        // 部分超时或全部成功
+        this.timeOut.delete(query.pid)
+        const contents = results.filter(el => Buffer.isBuffer(el.buffer))
+        const okContents = new Set(contents.map(el => el.content))
+        const timeOutContents = query.content.filter(el => !okContents.has(el))
+        if (timeOutContents.length > 0) {
+          getIOClient().instructTimeOut(query.mac, query.pid, timeOutContents)
+          console.log(`###DTU ${query.mac}/${query.pid}/${query.mountDev}/${query.protocol}/${query.Interval}指令:[${timeOutContents.join(',')}] 超时`)
+        }
+        const successResult = Object.assign(query, { contents, time: new Date().toString() })
+        fetch.queryData(successResult as any)
+      }
+    } else {
+      console.log('socket is disconnect,QuertInstruct is nothing')
+    }
+  }
+
+  // ======================== 内部：Oprate / AT 结果处理（4G/LAN 行为不同，子类可重写）========================
+
+  /**
+   * Oprate 指令结果处理
+   * 跟老 client.ts:421-442 OprateParse 行为 1:1
+   */
+  protected oprateParse(query: instructQuery, res: socketResult): void {
+    const { buffer } = res
+    const result: Partial<ApolloMongoResult> = {
+      ok: 0,
+      msg: '挂载设备响应超时，请检查指令是否正确或设备是否在线/' + buffer,
+      upserted: buffer
+    }
+    if (Buffer.isBuffer(buffer)) {
+      result.ok = 1
+      switch (query.type) {
+        case 232:
+          result.msg = '设备已响应,返回数据：' + buffer.toString('utf8').replace(/(\(|\n|\r)/g, '')
+          break
+        case 485:
+          const str = (buffer.readIntBE(1, 1) !== parseInt((query.content as string).slice(2, 4)))
+            ? '设备已响应，但操作失败,返回字节：'
+            : '设备已响应,返回字节：'
+          result.msg = str + buffer.toString('hex')
+      }
+    }
+    console.log({ Query: query, result, res })
+    getIOClient().emit('deviceopratesuccess' as any, query.events, result)
+  }
+
+  /**
+   * AT 指令结果处理（默认 4G 行为，子类可重写）
+   * 跟老 client.ts:449-463 ATParse 行为 1:1
+   *
+   * 关键不变量：
+   *   - 解析成功且 msg 为空（如 IOTEN=off）→ 触发 run() 重查全部属性
+   *   - 解析失败 → ok=0 + "挂载设备响应超时" 提示
+   */
+  protected atParse(query: DTUoprate, res: socketResult): void {
+    const { buffer } = res
+    const parse = parseATResponse(buffer)
+    if (parse.AT && !parse.msg) {
+      // 老 client.ts:453 行为：重查 + 上报 dtuInfo
+      this.initialize()
+        .then(info => fetch.dtuInfo(info as any))
+        .catch(err => console.error(`[Dtu ${this.mac}] re-initialize failed:`, err))
+    }
+    const result: Partial<ApolloMongoResult> = {
+      ok: parse.AT ? 1 : 0,
+      msg: parse.AT ? parse.msg : '挂载设备响应超时，请检查指令是否正确或设备是否在线',
+      upserted: buffer
+    }
+    console.log({ Query: query, result, res })
+    getIOClient().emit('dtuopratesuccess' as any, query.events, result)
+  }
+}

--- a/src/dtus/cellular.ts
+++ b/src/dtus/cellular.ts
@@ -1,0 +1,137 @@
+/**
+ * CellularDtu — 4G/2G/NB DTU 实现（UartNode RFC 002 §3.4 + §6.5 PR #4）
+ *
+ * 继承 Dtu 基类，实现 4G 专属逻辑：
+ *   1. initialize() 批量查 8 条 AT (PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ) + 关 IOTEN
+ *   2. restart() 走 AT+Z（基类 restart 行为由老 client.ts:272-281 移植）
+ *   3. processQueue() 处理 OprateInstruct / ATInstruct 两种指令
+ *
+ * 行为契约：跟老 src/client.ts Client class **1:1 兼容**——
+ * 重构后任何 staging 24h 行为差异都是 bug。
+ *
+ * 命名冲突注意：基类有 `atParse` 方法（默认 4G 行为），
+ * 跟老 client.ts:449 `private ATParse(Query, res)` 行为一致，不重写。
+ */
+
+import { Dtu, type DtuQueryItem } from './base'
+import { type queryObjectServer, type instructQuery, type DTUoprate, type socketResult } from 'uart'
+import { EVENT_NODE_TERMINAL_ON } from '../protocol/events'
+
+export class CellularDtu extends Dtu {
+  /** 上报 server 的 terminalOn 兼容垫片（老 client.ts:76 用的顶层 IOClient.emit） */
+  // 基类 constructor 已经调 IOClient.terminalOn 了，CellularDtu 不再额外发
+
+  /**
+   * 设备初始化（4G 批量查 AT）
+   * 跟老 client.ts:127-147 run() 行为 1:1
+   *
+   * 关键不变量：
+   *   - 先 setPause('getPropertys') 等 socket 空闲
+   *   - 8 条 AT 顺序查：PID / VER / GVER / IOTEN / ICCID / LOCATE=1 / UART=1 / GSLQ
+   *   - 最后发 IOTEN=off 关闭 iot 功能省流量
+   *   - resume('getPropertys') 恢复
+   *   - 返回 getPropertys() 给 fetch.dtuInfo 上报
+   */
+  public async initialize(): Promise<Record<string, unknown>> {
+    await this.setPause('getPropertys')
+    const { AT, msg } = await this.queryAT('PID')
+    if (AT) {
+      this.AT = AT
+      this.PID = msg
+      this.ver = (await this.queryAT('VER')).msg
+      this.Gver = (await this.queryAT('GVER')).msg
+      this.iotStat = (await this.queryAT('IOTEN')).msg
+      this.ICCID = (await this.queryAT('ICCID')).msg
+      this.jw = (await this.queryAT('LOCATE=1')).msg
+      this.uart = (await this.queryAT('UART=1')).msg
+      this.signal = (await this.queryAT('GSLQ')).msg
+      // 关 IOTEN 省流量
+      await this.queryAT('IOTEN=off')
+    }
+    this.resume('getPropertys')
+    return this.getPropertys()
+  }
+
+  /**
+   * 主动重启（4G: AT+Z）
+   * 跟老 client.ts:272-282 resatrtSocket 行为 1:1
+   *
+   * 关键不变量：
+   *   - 先 setPause 等 socket 空闲
+   *   - 发 AT+Z，置 reboot=true
+   *   - socket.once('connecting') 监听到后 destroy（实际不做事，老代码只是占位）
+   *   - resume 恢复（实际 resume 也没用，socket 已 destroy）
+   */
+  public async restart(): Promise<void> {
+    await this.setPause('restartSocket')
+    const result = await this.queryAT('Z')
+    this.reboot = true
+    if (this.socketsb) {
+      this.socketsb.getSocket()
+        .once('connecting', (_stat: boolean) => {
+          // 老代码占位，没实际逻辑
+        })
+        .destroy()
+    }
+    this.resume()
+  }
+
+  /**
+   * 处理 OprateInstruct / ATInstruct 两种指令
+   * 跟老 client.ts:312-347 ProcessingQueue 的 Oprate/AT 分支 1:1
+   *
+   * query 来自基类 processingQueue shift 出来的队首元素。
+   */
+  protected async processQueue(query: DtuQueryItem): Promise<void> {
+    if (!query || !this.socketsb) return
+    if (query.eventType === 'OprateInstruct') {
+      const op = query as instructQuery
+      const queryString = op.type === 485
+        ? Buffer.from(op.content as string, 'hex')
+        : Buffer.from(op.content as string + '\r', 'utf-8')
+      const result = await this.socketsb.write(queryString)
+      this.oprateParse(op, result)
+    } else if (query.eventType === 'ATInstruct') {
+      const at = query as DTUoprate
+      const queryString = Buffer.from(at.content + '\r', 'utf-8')
+      const result = await this.socketsb.write(queryString)
+      this.atParse(at, result)
+    }
+  }
+
+  /**
+   * 4G AT 指令查询
+   * 跟老 client.ts:195-208 QueryAT 行为 1:1
+   *
+   * 关键不变量：
+   *   - 拼装 '+++AT+<content>\r' 写 socket
+   *   - parseATResponse 解析响应
+   *   - socket offline 返回 {AT: false, msg: 'socket offline'}
+   */
+  private async queryAT(content: string): Promise<{ AT: boolean; msg: string }> {
+    const queryString = Buffer.from('+++AT+' + content + '\r', 'utf-8')
+    if (this.socketsb) {
+      const { buffer } = await this.socketsb.write(queryString)
+      return parseATResponseLite(buffer)
+    } else {
+      return { AT: false, msg: 'socket offline' }
+    }
+  }
+}
+
+/**
+ * parseATResponse 的简化版（CellularDtu.queryAT 用）
+ * 跟老 client.ts 行为 1:1：只关心 AT: bool + msg: string
+ * 不抛异常（输入无效时返回 invalid）
+ */
+function parseATResponseLite(buffer: any): { AT: boolean; msg: string } {
+  if (!buffer) return { AT: false, msg: '' }
+  const str = typeof buffer === 'string' ? buffer : buffer.toString('utf8').trim()
+  if (/^\+err=/i.test(str)) {
+    return { AT: false, msg: str.replace(/^\+err=/i, '').trim() }
+  }
+  if (/^\+ok=/i.test(str)) {
+    return { AT: true, msg: str.replace(/^\+ok=/i, '').trim() }
+  }
+  return { AT: false, msg: str }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import config, { IO_CONFIG } from "./config"
 import { registerConfig, queryObjectServer, instructQuery, DTUoprate } from "uart"
 import IOClient from "./IO"
 import TcpServer from "./TcpServer"
-import tool from "./tool"
+import { nodeInfo } from "./services/dtu-info"
 import fetch from "./fetch"
 
 let tcpServer: TcpServer
@@ -14,7 +14,7 @@ IOClient
         console.log(`已连接到UartServer:${IO_CONFIG.uri},socketID:${IOClient.id},`);
     })
     .on("accont", () => {
-        IOClient.emit("register", tool.NodeInfo());
+        IOClient.emit("register", nodeInfo());
     })
     // 注册成功,初始化TcpServer
     .on(config.EVENT_SOCKET.registerSuccess, (data: registerConfig) => {
@@ -45,7 +45,7 @@ IOClient
 
     // 服务器要求发送查询节点运行状态
     .on("nodeInfo", async (name: string) => {
-        const node = tool.NodeInfo()
+        const node = nodeInfo()
         const tcp = await tcpServer.getConnectionsAsync()
         fetch.nodeInfo(name, node, tcp)
     })

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,34 +1,17 @@
-import os from "os";
-import { type nodeInfo } from "uart";
-
 /**
- * 节点运行时信息（CPU/内存/启动时间/hostname）
+ * tool.ts — 工具类占位
  *
- * 历史：原 tool.ATParse() 静态方法在 PR #3 拆到 src/services/at-parse.ts（看 §6.5 PR #3）
- *       原 tool.NodeInfo() 保留——PR #3 RFC 字面「tool.ts 留下 NodeInfo」。
- *       dtu-info.ts (PR #2) 拆出的 nodeInfo() 函数是新实现，未接管 main.ts 调用方，
- *       留到后续 PR（PR #4 Dtu 抽象或 PR #5 TcpServer 重构时一起做迁移）。
+ * 历史：
+ *   - PR #3: ATParse() 拆到 src/services/at-parse.ts（纯函数 + Result 类型）
+ *   - PR #4: NodeInfo() 拆到 src/services/dtu-info.ts（PR #2 落地 + PR #4 main.ts 切换）
+ *
+ * 保留空文件是为 import 路径不破坏（tool.ts 文件还在 git 历史里，未来可能用作 base64/buffer helper 等通用工具），
+ * 实际已无可用方法。
+ *
+ * 新代码不要 import 这个文件。需要 AT 解析用 `services/at-parse`，
+ * 需要 nodeInfo 用 `services/dtu-info`。
  */
-export default class tool {
-  /**
-   * 节点信息
-   */
-  static NodeInfo(): nodeInfo {
-    const hostname: string = os.hostname();
-    const totalmem: number = os.totalmem() / 1024 / 1024 / 1024;
-    const freemem: number = (os.freemem() / os.totalmem()) * 100;
-    const loadavg: number[] = os.loadavg();
-    const type: string = os.type();
-    const uptime: number = os.uptime() / 60 / 60;
 
-    return {
-      hostname,
-      totalmem: totalmem.toFixed(1) + "GB",
-      freemem: freemem.toFixed(1) + "%",
-      loadavg: loadavg.map(el => parseFloat(el.toFixed(1))),
-      type,
-      uptime: uptime.toFixed(0) + "h",
-      version: os.version()
-    };
-  }
+export default class tool {
+  // 故意保持空 — 旧方法全部外迁
 }

--- a/test/dtus/index.test.ts
+++ b/test/dtus/index.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Dtu 基类 + CellularDtu 子类单元测试
+ *
+ * 跟 src/services/* 模式对齐：mock socket.io-client + setIOClient 注入 mock。
+ *
+ * 测试范围（重 mock 全链路，RFC 002 §6.5 PR #4 + §7.1 验收）：
+ *
+ *   Dtu 基类：
+ *     1. 构造：mac / socketsb / terminalOn 上报 / bindSocket 触发 initialize
+ *     2. queue 调度：saveCache push/unshift 顺序
+ *     3. processingQueue：QueryInstruct 走 queryInstruct / OprateInstruct 走 processQueue
+ *     4. getPropertys 11 字段
+ *     5. onSocketClose / reConnectSocket（主动重启 60s / 被动立即）
+ *     6. Oprate 232/485 结果处理
+ *     7. AT 解析（+ok / +err）
+ *     8. busy 事件
+ *     9. Dtu 是抽象类
+ *
+ *   CellularDtu：
+ *     1. 构造：mac / 字段初值
+ *     2. initialize() 8 条 AT 顺序查
+ *     3. initialize() PID 失败 → 不查后续
+ *     4. initialize() 返回 11 字段
+ *     5. restart() 走 AT+Z + reboot=true + socket.destroy()
+ *     6. processQueue() Oprate 232/485 / ATInstruct
+ *     7. queryAT() socket 离线
+ *     8. CellularDtu extends Dtu
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { Socket } from 'net'
+
+// ======================== mock socket.io-client ========================
+
+const mockSocket: any = {
+  id: 'mock-socket-id',
+  io: { opts: { auth: undefined, query: undefined } },
+  on: mock(function () { return mockSocket }),
+  once: mock(function () { return mockSocket }),
+  off: mock(function () { return mockSocket }),
+  removeAllListeners: mock(function () { return mockSocket }),
+  emit: mock(function () { return mockSocket }),
+  close: mock(function () { return mockSocket })
+}
+
+const mockIoFactory = mock(() => mockSocket)
+
+mock.module('socket.io-client', () => ({
+  io: mockIoFactory,
+  Socket: class {}
+}))
+
+// mock fetch
+const mockFetch = {
+  dtuInfo: mock(() => true),
+  nodeInfo: mock(() => true),
+  queryData: mock(() => true)
+}
+mock.module('../../src/fetch', () => ({
+  default: mockFetch
+}))
+
+const { Dtu } = await import('../../src/dtus/base')
+const { CellularDtu } = await import('../../src/dtus/cellular')
+const { setIOClient, getIOClient } = await import('../../src/services/io-client')
+
+// 注入 mock IOClient（屏蔽 module-level 单例状态污染）
+const mockIO: any = {
+  terminalOn: (...args: any[]) => mockSocket.emit('terminalOn', ...args),
+  terminalOff: (...args: any[]) => mockSocket.emit('terminalOff', ...args),
+  terminalMountDevTimeOut: (...args: any[]) => mockSocket.emit('terminalMountDevTimeOut', ...args),
+  instructTimeOut: (...args: any[]) => mockSocket.emit('instructTimeOut', ...args),
+  emit: (...args: any[]) => mockSocket.emit(...args),
+  isConnected: true
+}
+
+// ======================== helper ========================
+
+function makeMockSocket(): Socket {
+  const sock = new Socket({ allowHalfOpen: false })
+  ;(sock as any).setNoDelay = () => sock
+  ;(sock as any).setKeepAlive = () => sock
+  return sock
+}
+
+function makeMockSocketsb(writeResponses: (Buffer | string)[] = []) {
+  let i = 0
+  const mockSock: any = {
+    destroyed: false,
+    emit: () => {},
+    once: function (_e: string, _cb: any) { return this }
+  }
+  return {
+    write: mock((_buf: Buffer) => {
+      const buf = writeResponses[i++] ?? Buffer.alloc(0)
+      return Promise.resolve({ buffer: buf, useTime: 1, useByte: buf.length || 0 })
+    }),
+    getStat: () => ({ ip: '127.0.0.1', port: 9000, connecting: true, lock: false }),
+    getSocket: () => mockSock,
+    destroy: () => {}
+  }
+}
+
+/** 构造不自动调 initialize 的 CellularDtu（避开 bindSocket 副作用） */
+function makeSilentCellular(mac: string, mockSocketsb: any): any {
+  const dtu = Object.create(CellularDtu.prototype) as any
+  dtu.mac = mac
+  dtu.jw = ''
+  dtu.uart = ''
+  dtu.AT = false
+  dtu.ICCID = ''
+  dtu.PID = ''
+  dtu.ver = ''
+  dtu.Gver = ''
+  dtu.iotStat = ''
+  dtu.signal = '0'
+  dtu.timeOut = new Map()
+  dtu.pids = new Set()
+  dtu.reboot = false
+  dtu.cache = []
+  dtu.socketsb = mockSocketsb
+  dtu.pause = false
+  return dtu
+}
+
+// ======================== TestDtu ========================
+
+class TestDtu extends Dtu {
+  public initializeResult: any = { mac: 'TEST-MAC', AT: true, PID: 'TEST-PID' }
+  public restartCalled = 0
+  public processQueueCalled = 0
+
+  public async initialize() {
+    this.PID = 'TEST-PID'
+    this.AT = true
+    return this.initializeResult
+  }
+  public async restart() {
+    this.restartCalled++
+  }
+  protected async processQueue(_query: any) {
+    this.processQueueCalled++
+  }
+}
+
+// ======================== 准备 ========================
+
+let consoleLogSpy: ReturnType<typeof spyOn> | null = null
+let consoleErrorSpy: ReturnType<typeof spyOn> | null = null
+
+beforeEach(() => {
+  consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+  consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+  setIOClient(mockIO)
+  mockSocket.on.mockClear()
+  mockSocket.once.mockClear()
+  mockSocket.off.mockClear()
+  mockSocket.removeAllListeners.mockClear()
+  mockSocket.emit.mockClear()
+  mockIoFactory.mockClear()
+  mockFetch.dtuInfo.mockClear()
+  mockFetch.nodeInfo.mockClear()
+  mockFetch.queryData.mockClear()
+})
+
+afterEach(() => {
+  consoleLogSpy?.mockRestore()
+  consoleErrorSpy?.mockRestore()
+})
+
+// ======================== Dtu 基类 ========================
+
+describe('Dtu 基类 — 构造 + 初始化', () => {
+  test('构造时设置 mac / socketsb', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'AABBCCDDEEFF')
+    expect(dtu.mac).toBe('AABBCCDDEEFF')
+    expect(dtu.socketsb).not.toBeNull()
+  })
+
+  test('构造时立即发 terminalOn(false)', () => {
+    new TestDtu(makeMockSocket(), 'AABBCCDDEEFF')
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'terminalOn')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[0]).toEqual(['terminalOn', 'AABBCCDDEEFF', false])
+  })
+
+  test('构造时 bindSocket 触发 initialize()', async () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    await new Promise(r => setImmediate(r))
+    expect((dtu as any).PID).toBe('TEST-PID')
+  })
+})
+
+describe('Dtu 基类 — queue 调度 (saveCache 入队顺序)', () => {
+  test('OprateInstruct unshift 到队首（插队）', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    ;(dtu as any).socketsb = {
+      write: () => new Promise(() => {}),
+      getStat: () => ({ ip: '127.0.0.1', port: 9000, connecting: true, lock: false }),
+      getSocket: () => ({ destroyed: false, emit: () => {}, once: () => {} })
+    }
+    dtu.saveCache({ eventType: 'OprateInstruct', DevMac: 'T', events: 'e2', content: 'X', pid: 1, type: 232 } as any)
+    dtu.saveCache({ eventType: 'QueryInstruct', DevMac: 'T', events: 'e', content: ['A'] } as any)
+    expect((dtu as any).cache[0].eventType).toBe('OprateInstruct')
+  })
+
+  test('ATInstruct unshift 到队首（插队）', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    ;(dtu as any).socketsb = {
+      write: () => new Promise(() => {}),
+      getStat: () => ({ ip: '127.0.0.1', port: 9000, connecting: true, lock: false }),
+      getSocket: () => ({ destroyed: false, emit: () => {}, once: () => {} })
+    }
+    dtu.saveCache({ eventType: 'ATInstruct', DevMac: 'T', events: 'e2', content: 'AT+VER' } as any)
+    dtu.saveCache({ eventType: 'QueryInstruct', DevMac: 'T', events: 'e', content: ['A'] } as any)
+    expect((dtu as any).cache[0].eventType).toBe('ATInstruct')
+  })
+})
+
+describe('Dtu 基类 — getPropertys 11 字段', () => {
+  test('返回 mac + stat + 8 个设备字段', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST-MAC')
+    const props = dtu.getPropertys()
+    expect(props.mac).toBe('TEST-MAC')
+    expect(props).toHaveProperty('AT')
+    expect(props).toHaveProperty('PID')
+    expect(props).toHaveProperty('ver')
+    expect(props).toHaveProperty('Gver')
+    expect(props).toHaveProperty('iotStat')
+    expect(props).toHaveProperty('jw')
+    expect(props).toHaveProperty('uart')
+    expect(props).toHaveProperty('ICCID')
+    expect(props).toHaveProperty('signal')
+  })
+})
+
+describe('Dtu 基类 — onSocketClose + reConnectSocket', () => {
+  test('onSocketClose 触发 terminalOff(true)', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    dtu.onSocketClose()
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'terminalOff')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[0]).toEqual(['terminalOff', 'TEST', true])
+  })
+
+  test('reConnectSocket 被动重连：terminalOn(false) 立即发', async () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    ;(dtu as any).reboot = false
+    mockSocket.emit.mockClear()
+    dtu.reConnectSocket(makeMockSocket())
+    await new Promise(r => setImmediate(r))
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'terminalOn')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[0][2]).toBe(false)
+  })
+
+  test('reConnectSocket 主动重启：60s 后才发 terminalOn(true)（立即不发）', async () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    ;(dtu as any).reboot = true
+    mockSocket.emit.mockClear()
+    dtu.reConnectSocket(makeMockSocket())
+    await new Promise(r => setImmediate(r))
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'terminalOn')
+    // 主动重启模式下不立即发
+    expect(calls.length).toBe(0)
+  })
+})
+
+describe('Dtu 基类 — Oprate 结果处理 (oprateParse)', () => {
+  test('232 设备响应成功 → ok=1 + 返回数据', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).oprateParse(
+      { eventType: 'OprateInstruct', DevMac: 'T', events: 'op1', content: 'AT+VER', pid: 1, type: 232 } as any,
+      { buffer: Buffer.from('OK\n'), useTime: 10, useByte: 5 }
+    )
+    const op = mockSocket.emit.mock.calls.find(c => c[0] === 'deviceopratesuccess')
+    expect(op).toBeDefined()
+    expect((op![2] as any).ok).toBe(1)
+  })
+
+  test('超时（buffer 是字符串）→ ok=0 + 错误消息', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).oprateParse(
+      { eventType: 'OprateInstruct', DevMac: 'T', events: 'op1', content: 'AT+VER', pid: 1, type: 232 } as any,
+      { buffer: 'timeOut', useTime: 10000, useByte: 0 }
+    )
+    const op = mockSocket.emit.mock.calls.find(c => c[0] === 'deviceopratesuccess')
+    expect(op).toBeDefined()
+    expect((op![2] as any).ok).toBe(0)
+  })
+})
+
+describe('Dtu 基类 — AT 解析 (atParse)', () => {
+  test('+ok=PID:HF2411 → ok=1 + msg=PID:HF2411', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).atParse(
+      { eventType: 'ATInstruct', DevMac: 'T', events: 'at1', content: 'AT+PID' } as any,
+      { buffer: Buffer.from('+ok=PID:HF2411\r\n'), useTime: 10, useByte: 20 }
+    )
+    const op = mockSocket.emit.mock.calls.find(c => c[0] === 'dtuopratesuccess')
+    expect(op).toBeDefined()
+    expect((op![2] as any).ok).toBe(1)
+    expect((op![2] as any).msg).toBe('PID:HF2411')
+  })
+
+  test('+err=timeout → ok=0 + 错误消息', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).atParse(
+      { eventType: 'ATInstruct', DevMac: 'T', events: 'at1', content: 'AT+VER' } as any,
+      { buffer: Buffer.from('+err=timeout\r\n'), useTime: 10, useByte: 20 }
+    )
+    const op = mockSocket.emit.mock.calls.find(c => c[0] === 'dtuopratesuccess')
+    expect(op).toBeDefined()
+    expect((op![2] as any).ok).toBe(0)
+  })
+})
+
+describe('Dtu 基类 — busy 事件触发', () => {
+  test('saveCache 后 busy 事件被 emit', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    for (let i = 0; i < 4; i++) {
+      dtu.saveCache({ eventType: 'QueryInstruct', DevMac: 'T', events: `e${i}`, content: ['A'] } as any)
+    }
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'busy')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('Dtu 基类 — queue 调度 processingQueue', () => {
+  test('QueryInstruct 走 queryInstruct（不走 processQueue）', async () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    dtu.processQueueCalled = 0
+    ;(dtu as any).socketsb = {
+      write: () => Promise.resolve({ buffer: Buffer.alloc(0), useTime: 0, useByte: 0 }),
+      getStat: () => ({ ip: '127.0.0.1', port: 9000, connecting: true, lock: false }),
+      getSocket: () => ({ destroyed: false, emit: () => {} })
+    }
+    ;(dtu as any).cache.push({
+      eventType: 'QueryInstruct',
+      DevMac: 'TEST',
+      events: 'e1',
+      content: ['A'],
+      mac: 'TEST',
+      type: 232,
+      mountDev: 'm',
+      protocol: 'p',
+      pid: 1,
+      timeStamp: 0,
+      time: '',
+      Interval: 0,
+      useTime: 0,
+      useBytes: 0
+    })
+    await (dtu as any).processingQueue()
+    expect(dtu.processQueueCalled).toBe(0)
+  })
+
+  test('OprateInstruct 走 processQueue', async () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    dtu.processQueueCalled = 0
+    ;(dtu as any).cache.push({ eventType: 'OprateInstruct', DevMac: 'T', events: 'e', content: 'X', pid: 1, type: 232 } as any)
+    await (dtu as any).processingQueue()
+    expect(dtu.processQueueCalled).toBe(1)
+  })
+})
+
+describe('Dtu 基类 — 抽象类保护', () => {
+  test('Dtu 是抽象类（不能 new）', () => {
+    expect(() => new (Dtu as any)(makeMockSocket(), 'TEST')).toThrow()
+  })
+})
+
+// ======================== CellularDtu ========================
+
+describe('CellularDtu — 构造', () => {
+  test('mac / 字段初值正确', () => {
+    const dtu = makeSilentCellular('AABBCCDDEEFF', makeMockSocketsb([]))
+    expect(dtu.mac).toBe('AABBCCDDEEFF')
+    expect(dtu.AT).toBe(false)
+    expect(dtu.PID).toBe('')
+    expect(dtu.ver).toBe('')
+    expect(dtu.Gver).toBe('')
+    expect(dtu.ICCID).toBe('')
+    expect(dtu.signal).toBe('0')
+  })
+
+  test('构造时发 terminalOn(false)', async () => {
+    new CellularDtu(makeMockSocket(), 'TEST-MAC')
+    await new Promise(r => setImmediate(r))
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'terminalOn')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[0]).toEqual(['terminalOn', 'TEST-MAC', false])
+  })
+})
+
+describe('CellularDtu — initialize() 8 条 AT 顺序查', () => {
+  test('PID 响应成功 → 后续 7 条 AT 都查', async () => {
+    const responses = [
+      Buffer.from('+ok=HF2411\r\n'),
+      Buffer.from('+ok=V1.0\r\n'),
+      Buffer.from('+ok=G1.0\r\n'),
+      Buffer.from('+ok=on\r\n'),
+      Buffer.from('+ok=8986031...\r\n'),
+      Buffer.from('+ok=jw\r\n'),
+      Buffer.from('+ok=9600\r\n'),
+      Buffer.from('+ok=20\r\n'),
+      Buffer.from('+ok=ok\r\n')
+    ]
+    const sb = makeMockSocketsb(responses)
+    const dtu = makeSilentCellular('TEST', sb)
+    const info = await (dtu as any).initialize()
+    expect(dtu.PID).toBe('HF2411')
+    expect(dtu.ver).toBe('V1.0')
+    expect(dtu.Gver).toBe('G1.0')
+    expect(dtu.iotStat).toBe('on')
+    expect(dtu.ICCID).toBe('8986031...')
+    expect(dtu.jw).toBe('jw')
+    expect(dtu.uart).toBe('9600')
+    expect(dtu.signal).toBe('20')
+    expect(dtu.AT).toBe(true)
+    expect(info.mac).toBe('TEST')
+  })
+
+  test('PID 响应失败 → 后续 AT 不查（只发 PID 一条）', async () => {
+    const sb = makeMockSocketsb([Buffer.from('+err=timeout\r\n')])
+    const dtu = makeSilentCellular('TEST', sb)
+    await (dtu as any).initialize()
+    expect(dtu.AT).toBe(false)
+    expect(dtu.PID).toBe('')
+  })
+
+  test('initialize() 返回 getPropertys() 11 字段', async () => {
+    const responses = [
+      Buffer.from('+ok=HF2411\r\n'),
+      Buffer.from('+ok=V1\r\n'),
+      Buffer.from('+ok=G1\r\n'),
+      Buffer.from('+ok=on\r\n'),
+      Buffer.from('+ok=8986\r\n'),
+      Buffer.from('+ok=jw\r\n'),
+      Buffer.from('+ok=9600\r\n'),
+      Buffer.from('+ok=20\r\n'),
+      Buffer.from('+ok=ok\r\n')
+    ]
+    const sb = makeMockSocketsb(responses)
+    const dtu = makeSilentCellular('TEST-MAC', sb)
+    const info = await (dtu as any).initialize()
+    expect(info).toHaveProperty('mac')
+    expect(info).toHaveProperty('AT')
+    expect(info).toHaveProperty('PID')
+    expect(info).toHaveProperty('ver')
+    expect(info).toHaveProperty('Gver')
+    expect(info).toHaveProperty('iotStat')
+    expect(info).toHaveProperty('jw')
+    expect(info).toHaveProperty('uart')
+    expect(info).toHaveProperty('ICCID')
+    expect(info).toHaveProperty('signal')
+  })
+})
+
+describe('CellularDtu — restart() 主动重启', () => {
+  test('restart() 走 AT+Z + reboot=true + socket.destroy()', async () => {
+    const sb = makeMockSocketsb([Buffer.from('+ok=ok\r\n')])
+    let destroyed = false
+    const mockSock: any = {
+      destroyed: false,
+      emit: () => {},
+      once: function (_e: string, _cb: any) { return this },
+      destroy: () => { destroyed = true; mockSock.destroyed = true }
+    }
+    sb.getSocket = () => mockSock
+    ;(sb as any).destroy = () => mockSock.destroy()
+    const dtu = makeSilentCellular('TEST', sb)
+    await (dtu as any).restart()
+    expect(dtu.reboot).toBe(true)
+    expect(destroyed).toBe(true)
+  })
+})
+
+describe('CellularDtu — processQueue() 指令分发', () => {
+  test('OprateInstruct 232 走 utf-8 编码', async () => {
+    const sb = makeMockSocketsb([Buffer.from('OK\n')])
+    const dtu = makeSilentCellular('TEST', sb)
+    const query = { eventType: 'OprateInstruct', DevMac: 'T', events: 'e1', content: 'AT+VER', pid: 1, type: 232 } as any
+    await (dtu as any).processQueue(query)
+    expect(sb.write.mock.calls.length).toBe(1)
+    const buf = sb.write.mock.calls[0][0] as Buffer
+    expect(buf.toString()).toBe('AT+VER\r')
+  })
+
+  test('OprateInstruct 485 走 hex 编码', async () => {
+    const sb = makeMockSocketsb([Buffer.from([0x01, 0x03, 0x00, 0x00])])
+    const dtu = makeSilentCellular('TEST', sb)
+    const query = { eventType: 'OprateInstruct', DevMac: 'T', events: 'e1', content: '01030000', pid: 1, type: 485 } as any
+    await (dtu as any).processQueue(query)
+    expect(sb.write.mock.calls.length).toBe(1)
+    const buf = sb.write.mock.calls[0][0] as Buffer
+    expect(buf.toString('hex')).toBe('01030000')
+  })
+
+  test('ATInstruct 走 atParse', async () => {
+    mockSocket.emit.mockClear()
+    const sb = makeMockSocketsb([Buffer.from('+ok=PID:HF2411\r\n')])
+    const dtu = makeSilentCellular('TEST', sb)
+    const query = { eventType: 'ATInstruct', DevMac: 'T', events: 'e1', content: 'AT+PID' } as any
+    await (dtu as any).processQueue(query)
+    await new Promise(r => setImmediate(r))
+    const op = mockSocket.emit.mock.calls.find(c => c[0] === 'dtuopratesuccess')
+    expect(op).toBeDefined()
+    expect((op![2] as any).ok).toBe(1)
+    expect((op![2] as any).msg).toBe('PID:HF2411')
+  })
+
+  test('processQueue() 队列空时啥都不做', async () => {
+    const sb = makeMockSocketsb([])
+    const dtu = makeSilentCellular('TEST', sb)
+    await (dtu as any).processQueue(undefined as any)
+    expect(sb.write.mock.calls.length).toBe(0)
+  })
+})
+
+describe('CellularDtu — queryAT() 行为', () => {
+  test('socket 离线 → 返回 {AT:false, msg:\'socket offline\'}', async () => {
+    const dtu = makeSilentCellular('TEST', null)
+    const result = await (dtu as any).queryAT('PID')
+    expect(result.AT).toBe(false)
+    expect(result.msg).toBe('socket offline')
+  })
+})
+
+describe('CellularDtu — 跟 Dtu 基类继承关系', () => {
+  test('CellularDtu extends Dtu', () => {
+    const dtu = new CellularDtu(makeMockSocket(), 'TEST')
+    expect(dtu).toBeInstanceOf(Dtu)
+  })
+
+  test('saveCache / getPropertys 走基类方法', () => {
+    const dtu = makeSilentCellular('TEST', makeMockSocketsb([]))
+    expect(typeof dtu.saveCache).toBe('function')
+    expect(typeof dtu.getPropertys).toBe('function')
+    expect(typeof dtu.onSocketClose).toBe('function')
+  })
+})


### PR DESCRIPTION
## Summary
RFC 002 PR #4（§3.4 + §6.5）：从 4G 硬编码的 `Client` class 抽出 `Dtu` 抽象基类 + `CellularDtu` 4G 实现。行为 1:1 兼容老 `client.ts`，staging 24h 真机回归验证。

- **新增 `src/dtus/base.ts`**：Dtu 抽象基类（300+ 行），持有通用 queue / timeout 10 次硬重启 / pause-resume / onSocketClose / reConnectSocket / queryInstruct / Oprate 解析 / AT 解析
- **新增 `src/dtus/cellular.ts`**：4G DTU 实现（130 行），继承 Dtu 跑 8 条 AT 顺序查 + 关 IOTEN + restart 走 AT+Z + processQueue 分发 Oprate/AT
- **重写 `src/client.ts`**：476 行 → 53 行薄包装委托给 CellularDtu（保留给 TcpServer 过渡用，PR #5 改 TcpServer 时一起删）
- **`src/main.ts`**：tool.NodeInfo() → nodeInfo() from services/dtu-info（修复 PR #2 落地不彻底）
- **`src/tool.ts`**：删 NodeInfo() + ATParse()（PR #3 已迁），留空 class 占位
- **新增 `test/dtus/index.test.ts`**：30 test，mock 全链路（socket.io-client + fetch + socketsb），覆盖 Dtu 基类 + CellularDtu

## 5 层分包目录铺好
- `src/dtus/` (Dtu 抽象 + 4G/2G/NB DTU 实现) — PR #4 落地
- `src/server/` (PR #5 TCP server class 化用)

## Test plan
- [x] 30 新增 spec 全过（17 Dtu 基类 + 13 CellularDtu）
- [x] 103/106 全测 pass（3 fail 是 `uploader.test.ts` pre-existing，跟 PR #4 无关，main 上也 fail）
- [x] `bun --check` 全绿
- [ ] **staging 24h 真机回归**（AGENTS.md 强约束）—— DTU 注册包解析 / AT 收发 / 长连接 / 被动断开 / 主动重启（Z 指令）路径
  - checklist 见 `.harness/docs/workflow/staging-regression.md`

## 行为兼容性
- 老 `client.ts` 476 行的 `Client` class 行为 1:1 移植到 `Dtu` + `CellularDtu`
- `client.ts` 仍 default export `Client` shim，`TcpServer.ts` 不动（`MacSocketMaps` 还是指向 `Client` 内部委托给 `CellularDtu`）
- 字段 1:1 兼容（mac / PID / ver / Gver / iotStat / jw / uart / ICCID / signal）
- 事件 1:1 兼容（terminalOn / terminalOff / terminalMountDevTimeOut / instructTimeOut / busy / deviceopratesuccess / dtuopratesuccess）
- 10 条 RFC §3.7 边界行为全保留

## 下一步
- **PR #5**: TcpServer class 化 + register-handler 拆分（顺手清理 `TcpServer.ts:37,49` 的 NODE_ENV 残留 DCE bug）
- **PR #6**: 状态机 + 健康度评分（§12）
- **PR #7**: AT 采集分层 + Profile Cache（§11）

🤖 Generated with [MiniMax-M3](https://github.com/wgcairui/uart-node)