### PR TITLE
feat(dtus): DtuState 8 状态机 + 健康度评分 + 3 个新 Socket.IO 事件 (RFC 002 PR #6)

### DIFF
--- a/src/dtus/base.ts
+++ b/src/dtus/base.ts
@@ -30,6 +30,16 @@ import { EVENT_NODE_TERMINAL_OFF } from '../protocol/events'
 import { parseATResponse } from '../services/at-parse'
 import fetch from '../fetch'
 import config from '../config'
+import {
+  DtuState,
+  type DtuHealth,
+  type AlertType,
+  type DtuAlert,
+  computeHealth,
+  isValidTransition,
+  shouldReportHealth,
+  HEALTH_REPORT_INTERVAL_MS
+} from './state'
 
 /** Dtu 队列中的指令项（QueryInstruct / OprateInstruct / ATInstruct） */
 export type DtuQueryItem = queryObjectServer | instructQuery | DTUoprate
@@ -68,6 +78,24 @@ export abstract class Dtu {
   /** 暂停传输模式标志（initialize 期间置 true） */
   protected pause = false
 
+  // ======================== 状态机字段 (PR #6 落地, RFC 002 §12) ========================
+
+  /** 当前 DtuState（PR #6 落地） */
+  protected state: DtuState = DtuState.HANDSHAKING
+  /** DtuHealth 健康度指标（不存 score，按需 computeHealth() 派生） */
+  protected health: DtuHealth = {
+    score: 100,
+    lastCommAt: Date.now(),
+    consecutiveSuccesses: 0,
+    consecutiveFailures: 0,
+    queryTimeoutCount: 0,
+    totalRestarts: 0,
+    totalReconnects: 0,
+    signal: 0
+  }
+  /** dtuHealth 周期上报 timer (only ONLINE/DEGRADED, RFC §12.4) */
+  private healthReportTimer: ReturnType<typeof setInterval> | null = null
+
   constructor(socket: Socket, mac: string) {
     this.mac = mac
     // 代理 socket 跟老 client.ts 保持一致（ProxySocketsb 暂未启用，但 socketsb 内部已用 ProxySocket）
@@ -78,6 +106,105 @@ export abstract class Dtu {
 
     // 老 client.ts:80 行为 1:1：构造时绑定 socket 监听
     this.bindSocket(this.socketsb.getSocket())
+  }
+
+  // ======================== 状态机 API (PR #6 落地, RFC 002 §12) ========================
+
+  /**
+   * 状态转换（RFC §12.2 转换表 + §12.4 dtuState 事件）
+   *
+   * 行为契约：
+   *   1. 查 VALID_TRANSITIONS 转换表（不合法静默忽略, 避免破坏老 client.ts 隐式行为）
+   *   2. 幂等: 同状态不重复触发
+   *   3. emit dtuState 事件 ({mac, from, to, score, reason, timestamp})
+   *   4. 启停 dtuHealth 60s 周期上报（ONLINE/DEGRADED 启, 其它停）
+   *
+   * @param to 目标状态
+   * @param reason 触发原因（free string, ≤ 64 字符, 不能为空, cairui 拍板）
+   */
+  protected transition(to: DtuState, reason: string): void {
+    const from = this.state
+    // 幂等检查
+    if (from === to) return
+    // 合法性检查（不合法静默忽略, 老 client.ts 没显式状态机，宽松行为）
+    if (!isValidTransition(from, to)) {
+      console.warn(`[Dtu ${this.mac}] invalid transition: ${from} -> ${to} (reason: ${reason})`)
+      return
+    }
+    // 更新 state
+    this.state = to
+    // 重新计算 score（health 字段已被外部更新过）
+    this.health.score = computeHealth(this.health)
+    // emit dtuState 事件
+    getIOClient().dtuState({
+      mac: this.mac,
+      from,
+      to,
+      score: this.health.score,
+      reason: reason.slice(0, 64),
+      timestamp: Date.now()
+    })
+    console.log(`[Dtu ${this.mac}] state: ${from} -> ${to} (score=${this.health.score}, reason: ${reason})`)
+    // 启停 dtuHealth 60s 周期上报
+    if (shouldReportHealth(to)) {
+      this.startHealthReport()
+    } else {
+      this.stopHealthReport()
+    }
+  }
+
+  /**
+   * 启动 dtuHealth 60s 周期上报（RFC §12.4）
+   * 重复调用幂等（已有 timer 不重建）
+   */
+  private startHealthReport(): void {
+    if (this.healthReportTimer) return
+    this.healthReportTimer = setInterval(() => this.emitHealth(), HEALTH_REPORT_INTERVAL_MS)
+  }
+
+  /**
+   * 停止 dtuHealth 60s 周期上报
+   */
+  private stopHealthReport(): void {
+    if (this.healthReportTimer) {
+      clearInterval(this.healthReportTimer)
+      this.healthReportTimer = null
+    }
+  }
+
+  /**
+   * emit dtuHealth 事件（RFC §12.4）
+   * 60s 周期调用一次, 仅 ONLINE/DEGRADED 状态
+   */
+  protected emitHealth(): void {
+    if (!shouldReportHealth(this.state)) return
+    // 重新计算 score
+    this.health.score = computeHealth(this.health)
+    getIOClient().dtuHealth({
+      mac: this.mac,
+      score: this.health.score,
+      health: {
+        lastCommAt: this.health.lastCommAt,
+        consecutiveSuccesses: this.health.consecutiveSuccesses,
+        consecutiveFailures: this.health.consecutiveFailures,
+        queryTimeoutCount: this.health.queryTimeoutCount,
+        totalRestarts: this.health.totalRestarts,
+        totalReconnects: this.health.totalReconnects,
+        signal: this.health.signal
+      },
+      timestamp: Date.now()
+    })
+  }
+
+  /**
+   * emit dtuAlert 事件（RFC §12.4 + §12.4.2）
+   * 4 类: AT_TIMEOUT / INVALID_REGISTER / PROFILE_CACHE_FAIL / FATAL
+   *
+   * @param alert 完整 alert payload (mac 可为 null for INVALID_REGISTER/FATAL)
+   */
+  protected emitAlert(alert: DtuAlert): void {
+    getIOClient().dtuAlert(alert)
+    console.log(`[Dtu ${alert.mac ?? '<null>'}] alert: ${alert.type} - ${alert.message}`)
   }
 
   // ======================== 抽象方法（子类必须实现）========================
@@ -114,11 +241,24 @@ export abstract class Dtu {
     this.initialize()
       .then(info => {
         fetch.dtuInfo(info as any)
+        // PR #6: initialize() 成功 → transition ONLINE
+        this.transition(DtuState.ONLINE, 'initialize_ok')
+        this.health.lastCommAt = Date.now()
+        this.health.consecutiveSuccesses++
+        this.health.consecutiveFailures = 0
       })
       .catch(err => {
         // 老 client.ts 用 promise 没 catch，错误会被 unhandledRejection 兜底
         // 这里加 console.error 方便 staging 24h 观察
         console.error(`[Dtu ${this.mac}] initialize failed:`, err)
+        // PR #6: initialize() 失败 → emit AT_TIMEOUT alert (mac 已知, 完整设备层)
+        this.emitAlert({
+          mac: this.mac,
+          type: 'AT_TIMEOUT',
+          message: `[dtu] initialize: AT queries failed: ${(err as Error).message}`,
+          timestamp: Date.now()
+        })
+        this.transition(DtuState.OFFLINE, 'initialize_failed')
       })
 
     socket
@@ -133,6 +273,9 @@ export abstract class Dtu {
         this.setPause('close')
         socket.destroy()
         this.socketsb = null
+        // PR #6: socket close → transition OFFLINE + 停 60s 上报
+        this.transition(DtuState.OFFLINE, 'socket_close')
+        this.stopHealthReport()
       })
       // 监听新指令入队 → 触发队列处理
       .on('Queue', () => {

--- a/src/dtus/state.ts
+++ b/src/dtus/state.ts
@@ -1,0 +1,284 @@
+/**
+ * DTU 生命周期状态机 + 健康度评分（UartNode RFC 002 §12）
+ *
+ * 跟 src/protocol/events.ts 的 DtuState / DtuStateEvent / DtuHealthEvent / DtuAlertEvent / AlertType
+ * 类型对齐，但本文件是 **纯逻辑层**（纯函数 + enum），不依赖 socket.io / net / fetch。
+ *
+ * 设计要点（cairui 2026-06-15 拍板）：
+ *   - 8 个显式状态（CONNECTING / HANDSHAKING / INITIALIZING / ONLINE / DEGRADED
+ *     / RECONNECTING / RESTARTING / OFFLINE）
+ *   - 健康度 0-100，computeHealth(h) 纯函数
+ *   - 4 类 alert（AT_TIMEOUT / INVALID_REGISTER / PROFILE_CACHE_FAIL / FATAL）
+ *   - dtuState 事件 latest-wins 覆盖（server 端按 mac 覆盖，不维护事件流）
+ *   - dtubusy 跟 dtuState 是两条独立链路（dtubusy 是审计层不 emit socket 推前端）
+ *   - server 端 5min 去重（同 mac+type+message 不重推）
+ *
+ * 集成：
+ *   - src/dtus/base.ts 集成 DtuState 字段 + transition() + 3 个新事件 emit
+ *   - src/services/io-client.ts 已有 dtuState / dtuHealth / dtuAlert 业务方法
+ *   - 60s 周期上报：只在 ONLINE / DEGRADED 状态触发
+ */
+
+// ======================== DtuState enum ========================
+
+/**
+ * 8 个生命周期状态（RFC §12.1）
+ *
+ * 转换规则（RFC §12.2 转换表）：
+ *   - 初始 → CONNECTING（TCP socket accepted）
+ *   - CONNECTING → HANDSHAKING（注册包解析成功）
+ *   - CONNECTING → OFFLINE（10s 无注册包）
+ *   - HANDSHAKING → INITIALIZING（5 条必查 AT 全部返回）
+ *   - HANDSHAKING → OFFLINE（AT 查询超时 > 30s）
+ *   - INITIALIZING → ONLINE（第二层定时器启动成功）
+ *   - ONLINE → DEGRADED（连续 3 次查询失败 / signal < 5）
+ *   - DEGRADED → ONLINE（连续 5 次查询成功 / signal > 10）
+ *   - ONLINE/DEGRADED → RECONNECTING（socket close + 非 ECONNRESET）
+ *   - RECONNECTING → ONLINE（重连成功）
+ *   - RECONNECTING → OFFLINE（重试 5 次失败 / 总等待 > 60s）
+ *   - 任何状态 → RESTARTING（resatrtSocket / server 下发 AT+Z）
+ *   - RESTARTING → ONLINE（60s 内收到注册包）
+ *   - RESTARTING → OFFLINE（60s 内未重连）
+ *   - 任何状态 → OFFLINE（socket.on('error') 且非断连重试）
+ */
+export enum DtuState {
+  /** TCP socket accepted，等 10s 内注册包 */
+  CONNECTING = 'CONNECTING',
+  /** 注册包解析成功，等首次 AT 查询完成 */
+  HANDSHAKING = 'HANDSHAKING',
+  /** 第一层 AT 完成，terminalOn 上报，timer 启动 */
+  INITIALIZING = 'INITIALIZING',
+  /** 在线，缓存队列处理中（没有 query 堆积 / timeout）*/
+  ONLINE = 'ONLINE',
+  /** 在线但有 N 次连续失败（查询超时 / socket 抖动），还没掉线 */
+  DEGRADED = 'DEGRADED',
+  /** 重连中（被动断开后）*/
+  RECONNECTING = 'RECONNECTING',
+  /** 主动重启中（AT+Z 触发）*/
+  RESTARTING = 'RESTARTING',
+  /** 永久离线（放弃重连 / 重启失败 / server 主动踢）*/
+  OFFLINE = 'OFFLINE'
+}
+
+// ======================== DtuHealth ========================
+
+/**
+ * DTU 健康度指标（RFC §12.3）
+ * - score 由 computeHealth(h) 派生，0-100
+ * - 其余字段是原始指标，用于 computeHealth 输入
+ */
+export interface DtuHealth {
+  /** 0-100 健康度分数（computeHealth 派生） */
+  score: number
+  /** 最后一次成功通信时间戳（ms） */
+  lastCommAt: number
+  /** 连续成功计数 */
+  consecutiveSuccesses: number
+  /** 连续失败计数 */
+  consecutiveFailures: number
+  /** 累计查询超时次数 */
+  queryTimeoutCount: number
+  /** 累计硬重启次数 */
+  totalRestarts: number
+  /** 累计重连次数 */
+  totalReconnects: number
+  /** 当前 GPRS 信号强度（0-31） */
+  signal: number
+}
+
+// ======================== computeHealth 纯函数 ========================
+
+/**
+ * 计算 DTU 健康度分数（RFC §12.3 算法）
+ *
+ * 起点 100
+ *   - 最近通信时间扣分：每分钟无通信 -5，max -30
+ *   - 信号弱扣分：< 5 扣 20 / < 10 扣 10 / < 15 扣 5
+ *   - 连续失败扣分：每 +1 连续失败 -10，max -40
+ *   - 重启次数扣分：每 +1 重启 -5，max -20
+ *   - 范围 [0, 100]
+ *
+ * @param h 健康度原始指标（不含 score 字段）
+ * @param now 当前时间戳（默认 Date.now()，可注入用于测试）
+ * @returns 0-100 整数
+ */
+export function computeHealth(
+  h: Omit<DtuHealth, 'score'>,
+  now: number = Date.now()
+): number {
+  let score = 100
+  // 最近通信时间扣分
+  const minutesSinceComm = Math.floor((now - h.lastCommAt) / 60_000)
+  score -= Math.min(30, minutesSinceComm * 5)
+  // 信号弱扣分
+  if (h.signal < 5) score -= 20
+  else if (h.signal < 10) score -= 10
+  else if (h.signal < 15) score -= 5
+  // 连续失败扣分
+  score -= Math.min(40, h.consecutiveFailures * 10)
+  // 重启次数扣分
+  score -= Math.min(20, h.totalRestarts * 5)
+  return Math.max(0, Math.min(100, Math.round(score)))
+}
+
+// ======================== 健康度阈值 ========================
+
+export const HEALTH_THRESHOLD_HEALTHY = 80
+export const HEALTH_THRESHOLD_DEGRADED = 40
+
+/**
+ * 健康度区间（RFC §12.3 关键阈值）
+ *   - score >= 80: 健康
+ *   - 60-79:      轻度降级（打 log，不打 alarm）
+ *   - 40-59:      严重降级（DEGRADED 状态 + 打 alarm）
+ *   - < 40:       病危（触发 RESTARTING）
+ *   - 0:          死亡（OFFLINE + 从 MacSocketMaps 删除）
+ */
+export type HealthTier = 'HEALTHY' | 'MILD_DEGRADED' | 'SEVERE_DEGRADED' | 'CRITICAL' | 'DEAD'
+
+export function healthTier(score: number): HealthTier {
+  if (score >= HEALTH_THRESHOLD_HEALTHY) return 'HEALTHY'
+  if (score >= 60) return 'MILD_DEGRADED'
+  if (score >= HEALTH_THRESHOLD_DEGRADED) return 'SEVERE_DEGRADED'
+  if (score > 0) return 'CRITICAL'
+  return 'DEAD'
+}
+
+// ======================== 状态转换表 ========================
+
+/**
+ * 合法转换集合（RFC §12.2 转换表，幂等：同状态不重复触发）
+ *
+ * 用 Set<string> 存储 `${from}->${to}` 字符串，比 nested Map 易读。
+ */
+const VALID_TRANSITIONS = new Set<string>([
+  // 初始 → CONNECTING
+  '->CONNECTING',
+  // 注册路径
+  'CONNECTING->HANDSHAKING',
+  'CONNECTING->OFFLINE',
+  // 初始化路径
+  'HANDSHAKING->INITIALIZING',
+  'HANDSHAKING->OFFLINE',
+  'INITIALIZING->ONLINE',
+  // PR #6: CellularDtu 一次性 8 条 AT 全查, HANDSHAKING → ONLINE 直转
+  // (RFC §12.2 写的是 INITIALIZING → ONLINE, 但 §11.7 分层落地前一次性查完)
+  // 留 INITIALIZING → ONLINE 给未来分层用
+  'HANDSHAKING->ONLINE',
+  // 健康度摆动
+  'ONLINE->DEGRADED',
+  'DEGRADED->ONLINE',
+  'DEGRADED->DEGRADED',  // 允许 DEGRADED → DEGRADED（连续失败但还没恢复）
+  // 重连路径
+  'ONLINE->RECONNECTING',
+  'DEGRADED->RECONNECTING',
+  'RECONNECTING->ONLINE',
+  'RECONNECTING->OFFLINE',
+  // 重启路径
+  'ONLINE->RESTARTING',
+  'DEGRADED->RESTARTING',
+  'RECONNECTING->RESTARTING',
+  'RESTARTING->ONLINE',
+  'RESTARTING->OFFLINE',
+  // 任何状态 → OFFLINE（错误兜底）
+  'CONNECTING->OFFLINE',
+  'HANDSHAKING->OFFLINE',
+  'INITIALIZING->OFFLINE',
+  'ONLINE->OFFLINE',
+  'DEGRADED->OFFLINE',
+  'RECONNECTING->OFFLINE',
+  'RESTARTING->OFFLINE',
+  // 任何状态 → RESTARTING（AT+Z 触发）
+  'INITIALIZING->RESTARTING'
+])
+
+/**
+ * 检查状态转换是否合法（RFC §12.2 转换表）
+ * 同状态转换允许（幂等），用于"已经 ONLINE 还想转 ONLINE"场景
+ */
+export function isValidTransition(from: DtuState, to: DtuState): boolean {
+  return VALID_TRANSITIONS.has(`${from}->${to}`)
+}
+
+// ======================== 4 类 AlertType ========================
+
+/**
+ * 4 个告警类型（cairui 2026-06-15 拍板）
+ *
+ * 触发位置（RFC §12.4.2）：
+ *   - AT_TIMEOUT: client.run() 连续 3 次 AT 查询超时（src/dtus/base.ts:queryInstruct）
+ *   - INVALID_REGISTER: sniff register 包解析失败（src/server/tcp-server.ts:onConnection）
+ *   - PROFILE_CACHE_FAIL: /api/node/dtu-info-cache GET/POST 连续 5 次失败（PR #7 落地）
+ *   - FATAL: 进程级 fatal（main.ts catch，mac: null）
+ */
+export type AlertType = 'AT_TIMEOUT' | 'INVALID_REGISTER' | 'PROFILE_CACHE_FAIL' | 'FATAL'
+
+/**
+ * DtuAlert payload（RFC §12.4）
+ * - mac: string | null（INVALID_REGISTER / FATAL 时为 null）
+ * - type: 4 类之一
+ * - message: Node 端拼（RFC §3.7.3 格式 `[<layer>] <context>: <what>: <why>`）
+ * - context?: 额外上下文（remoteAddr / firstPacket / stack）
+ * - timestamp: ms
+ */
+export interface DtuAlert {
+  mac: string | null
+  type: AlertType
+  message: string
+  context?: Record<string, unknown>
+  timestamp: number
+}
+
+// ======================== 重连退避 ========================
+
+/**
+ * 重连退避算法（RFC §12.5）
+ *
+ * 关键：UartNode 不能主动 dial DTU（DTU 在 NAT 后），
+ * 所以退避是"server 侧等待"，不是 socket 主动重拨。
+ *
+ * 算法：baseMs = min(16_000, 1000 * 2^(attempt-1)) + jitter(0-500ms)
+ *   - 第 1 次：1s + jitter
+ *   - 第 2 次：2s + jitter
+ *   - 第 3 次：4s + jitter
+ *   - 第 4 次：8s + jitter
+ *   - 第 5 次：16s + jitter (max)
+ */
+export const MAX_RECONNECT_ATTEMPTS = 5
+export const MAX_RECONNECT_WAIT_MS = 60_000
+export const MAX_RECONNECT_BACKOFF_MS = 16_000
+
+export interface ReconnectBackoffParams {
+  attempt: number          // 1-based
+  maxAttempts?: number
+  maxBackoffMs?: number
+  random?: () => number     // 注入用于测试（默认 Math.random）
+}
+
+export function computeReconnectBackoff({
+  attempt,
+  maxAttempts = MAX_RECONNECT_ATTEMPTS,
+  maxBackoffMs = MAX_RECONNECT_BACKOFF_MS,
+  random = Math.random
+}: ReconnectBackoffParams): { waitMs: number; shouldRetry: boolean } {
+  if (attempt > maxAttempts) {
+    return { waitMs: 0, shouldRetry: false }
+  }
+  const baseMs = Math.min(maxBackoffMs, 1000 * 2 ** (attempt - 1))
+  const jitter = random() * 500
+  return { waitMs: Math.round(baseMs + jitter), shouldRetry: true }
+}
+
+// ======================== 上报间隔 ========================
+
+/** dtuHealth 周期上报间隔（RFC §12.4：每 60s 一次，ONLINE/DEGRADED 才发） */
+export const HEALTH_REPORT_INTERVAL_MS = 60_000
+
+/**
+ * 判断 dtuHealth 周期上报是否应该触发
+ * - ONLINE / DEGRADED：true
+ * - 其它状态：false
+ */
+export function shouldReportHealth(state: DtuState): boolean {
+  return state === DtuState.ONLINE || state === DtuState.DEGRADED
+}

--- a/test/dtus/index.test.ts
+++ b/test/dtus/index.test.ts
@@ -71,6 +71,10 @@ const mockIO: any = {
   terminalMountDevTimeOut: (...args: any[]) => mockSocket.emit('terminalMountDevTimeOut', ...args),
   instructTimeOut: (...args: any[]) => mockSocket.emit('instructTimeOut', ...args),
   emit: (...args: any[]) => mockSocket.emit(...args),
+  // PR #6 新增 3 个状态机事件
+  dtuState: (event: any) => mockSocket.emit('dtuState', event),
+  dtuHealth: (event: any) => mockSocket.emit('dtuHealth', event),
+  dtuAlert: (event: any) => mockSocket.emit('dtuAlert', event),
   isConnected: true
 }
 

--- a/test/dtus/integration.test.ts
+++ b/test/dtus/integration.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Dtu 基类状态机集成测试（RFC 002 §12 集成落地）
+ *
+ * 跟 test/dtus/state.test.ts 互补：state.test.ts 测纯函数（DtuState enum + computeHealth + 转换表），
+ * 本文件测集成到 Dtu 基类后的行为（transition / emit dtuState / emit dtuHealth / emit dtuAlert / 60s 上报）。
+ *
+ * 测试范围（10 test, mock socket + IOClient）：
+ *   1. 初始 state = HANDSHAKING
+ *   2. transition(ONLINE) → emit dtuState 事件 (HANDSHAKING → ONLINE)
+ *   3. transition 幂等：同状态不重复 emit
+ *   4. transition 不合法 → 静默忽略，不 emit
+ *   5. initialize 成功 → transition ONLINE + 启 60s 上报
+ *   6. initialize 失败 → emit AT_TIMEOUT alert + transition OFFLINE
+ *   7. socket close → transition OFFLINE + 停 60s 上报
+ *   8. emit dtuHealth 内容（ONLINE 状态）
+ *   9. emit dtuAlert 4 类 payload 正确
+ *   10. reason 字符串超 64 字符截断
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { Socket } from 'net'
+
+// ======================== mock socket.io-client ========================
+
+const mockSocket: any = {
+  id: 'mock-socket-id',
+  io: { opts: { auth: undefined, query: undefined } },
+  on: mock(function () { return mockSocket }),
+  once: mock(function () { return mockSocket }),
+  off: mock(function () { return mockSocket }),
+  removeAllListeners: mock(function () { return mockSocket }),
+  emit: mock(function () { return mockSocket }),
+  close: mock(function () { return mockSocket })
+}
+
+const mockIoFactory = mock(() => mockSocket)
+
+mock.module('socket.io-client', () => ({
+  io: mockIoFactory,
+  Socket: class {}
+}))
+
+const mockFetch = {
+  dtuInfo: mock(() => true),
+  nodeInfo: mock(() => true),
+  queryData: mock(() => true)
+}
+mock.module('../../src/fetch', () => ({
+  default: mockFetch
+}))
+
+const { Dtu } = await import('../../src/dtus/base')
+const { DtuState, HEALTH_REPORT_INTERVAL_MS } = await import('../../src/dtus/state')
+const { setIOClient, getIOClient } = await import('../../src/services/io-client')
+
+const mockIO: any = {
+  terminalOn: (...args: any[]) => mockSocket.emit('terminalOn', ...args),
+  terminalOff: (...args: any[]) => mockSocket.emit('terminalOff', ...args),
+  terminalMountDevTimeOut: (...args: any[]) => mockSocket.emit('terminalMountDevTimeOut', ...args),
+  instructTimeOut: (...args: any[]) => mockSocket.emit('instructTimeOut', ...args),
+  emit: (...args: any[]) => mockSocket.emit(...args),
+  dtuState: (event: any) => mockSocket.emit('dtuState', event),
+  dtuHealth: (event: any) => mockSocket.emit('dtuHealth', event),
+  dtuAlert: (event: any) => mockSocket.emit('dtuAlert', event),
+  isConnected: true
+}
+
+// ======================== helper ========================
+
+function makeMockSocket(): any {
+  const listeners: Record<string, ((...args: any[]) => void)[]> = {}
+  const onceListeners: Record<string, ((...args: any[]) => void)[]> = {}
+  const sock: any = {
+    remoteAddress: '1.2.3.4',
+    remotePort: 9000,
+    destroyed: false,
+    writable: true,
+    setNoDelay: () => sock,
+    setKeepAlive: () => sock,
+    setTimeout: () => sock,
+    write: () => true,
+    end: () => sock,
+    destroy: () => { sock.destroyed = true },
+    on: mock((event: string, cb: (...args: any[]) => void) => {
+      if (!listeners[event]) listeners[event] = []
+      listeners[event].push(cb)
+      return sock
+    }),
+    once: mock((event: string, cb: (...args: any[]) => void) => {
+      if (!onceListeners[event]) onceListeners[event] = []
+      onceListeners[event].push(cb)
+      return sock
+    }),
+    emit: mock((event: string, ...args: any[]) => {
+      const cbs = listeners[event] || []
+      for (const cb of cbs) cb(...args)
+      const onceCbs = onceListeners[event] || []
+      onceListeners[event] = []
+      for (const cb of onceCbs) cb(...args)
+      return true
+    })
+  }
+  return sock
+}
+
+class TestDtu extends Dtu {
+  public initializeResult: any = { mac: 'TEST-MAC', AT: true }
+  public async initialize() {
+    return this.initializeResult
+  }
+  public async restart() {}
+  protected async processQueue(_query: any) {}
+}
+
+// ======================== 准备 ========================
+
+let consoleLogSpy: ReturnType<typeof spyOn> | null = null
+let consoleErrorSpy: ReturnType<typeof spyOn> | null = null
+let consoleWarnSpy: ReturnType<typeof spyOn> | null = null
+
+beforeEach(() => {
+  consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+  consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+  consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+  setIOClient(mockIO)
+  mockSocket.on.mockClear()
+  mockSocket.once.mockClear()
+  mockSocket.off.mockClear()
+  mockSocket.removeAllListeners.mockClear()
+  mockSocket.emit.mockClear()
+  mockIoFactory.mockClear()
+  mockFetch.dtuInfo.mockClear()
+})
+
+afterEach(() => {
+  consoleLogSpy?.mockRestore()
+  consoleErrorSpy?.mockRestore()
+  consoleWarnSpy?.mockRestore()
+})
+
+// ======================== 测试 ========================
+
+describe('Dtu 基类 — 状态机集成', () => {
+  test('初始 state = HANDSHAKING（构造时）', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    expect((dtu as any).state).toBe(DtuState.HANDSHAKING)
+  })
+
+  test('transition(ONLINE) → emit dtuState 事件 (HANDSHAKING → ONLINE)', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).transition(DtuState.ONLINE, 'test_ok')
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    expect(calls.length).toBe(1)
+    const event = calls[0][1] as any
+    expect(event.mac).toBe('TEST')
+    expect(event.from).toBe(DtuState.HANDSHAKING)
+    expect(event.to).toBe(DtuState.ONLINE)
+    expect(typeof event.score).toBe('number')
+    expect(event.reason).toBe('test_ok')
+    expect(typeof event.timestamp).toBe('number')
+  })
+
+  test('transition 幂等：同状态不重复 emit', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    ;(dtu as any).transition(DtuState.ONLINE, 'first')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).transition(DtuState.ONLINE, 'second')
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    expect(calls.length).toBe(0)
+  })
+
+  test('transition 不合法 → 静默忽略', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    // 初始 HANDSHAKING → ONLINE 是合法的，转一次
+    ;(dtu as any).transition(DtuState.ONLINE, 'init')
+    mockSocket.emit.mockClear()
+    // OFFLINE → ONLINE 不合法（OFFLINE 是终态）
+    ;(dtu as any).transition(DtuState.OFFLINE, 'force')  // OFFLINE 合法
+    ;(dtu as any).transition(DtuState.ONLINE, 'invalid_back')  // OFFLINE → ONLINE 不合法
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    // 只应该有 ONLINE → OFFLINE 一次，OFFLINE → ONLINE 静默忽略
+    expect(calls.length).toBe(1)
+    expect(calls[0][1].to).toBe(DtuState.OFFLINE)
+  })
+
+  test('initialize 成功 → transition ONLINE', async () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    await new Promise(r => setImmediate(r))
+    expect((dtu as any).state).toBe(DtuState.ONLINE)
+  })
+
+  test('initialize 失败 → emit AT_TIMEOUT alert + transition OFFLINE', async () => {
+    class FailDtu extends Dtu {
+      public async initialize() {
+        throw new Error('AT queries failed')
+      }
+      public async restart() {}
+      protected async processQueue(_query: any) {}
+    }
+    new FailDtu(makeMockSocket(), 'FAIL-MAC')
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+    const alertCalls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuAlert')
+    expect(alertCalls.length).toBeGreaterThanOrEqual(1)
+    const alert = alertCalls[0][1] as any
+    expect(alert.type).toBe('AT_TIMEOUT')
+    expect(alert.mac).toBe('FAIL-MAC')
+    const stateCalls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    const offlineCall = stateCalls.find(c => (c[1] as any).to === DtuState.OFFLINE)
+    expect(offlineCall).toBeDefined()
+  })
+
+  test('socket close → transition OFFLINE + 停 60s 上报', async () => {
+    const sock = makeMockSocket()
+    const dtu = new TestDtu(sock, 'TEST')
+    await new Promise(r => setImmediate(r))
+    // 先转 ONLINE 启 60s 上报
+    expect((dtu as any).state).toBe(DtuState.ONLINE)
+    expect((dtu as any).healthReportTimer).not.toBeNull()
+    mockSocket.emit.mockClear()
+    // 触发 close
+    sock.emit('close')
+    await new Promise(r => setImmediate(r))
+    // state 应转 OFFLINE，60s 上报停
+    expect((dtu as any).state).toBe(DtuState.OFFLINE)
+    expect((dtu as any).healthReportTimer).toBeNull()
+    const stateCalls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    const offlineCall = stateCalls.find(c => (c[1] as any).to === DtuState.OFFLINE)
+    expect(offlineCall).toBeDefined()
+  })
+})
+
+describe('Dtu 基类 — emitHealth / emitAlert', () => {
+  test('emitHealth 仅在 ONLINE/DEGRADED 状态触发', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    ;(dtu as any).transition(DtuState.ONLINE, 'test')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).emitHealth()
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuHealth')
+    expect(calls.length).toBe(1)
+    const event = calls[0][1] as any
+    expect(event.mac).toBe('TEST')
+    expect(event.score).toBeGreaterThanOrEqual(0)
+    expect(event.score).toBeLessThanOrEqual(100)
+    expect(event.health).toBeDefined()
+    expect(typeof event.health.lastCommAt).toBe('number')
+    expect(typeof event.health.signal).toBe('number')
+  })
+
+  test('emitAlert 4 类 payload 正确', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).emitAlert({
+      mac: 'TEST',
+      type: 'AT_TIMEOUT',
+      message: '[dtu] test: AT failed',
+      timestamp: Date.now()
+    })
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuAlert')
+    expect(calls.length).toBe(1)
+    const event = calls[0][1] as any
+    expect(event.type).toBe('AT_TIMEOUT')
+    expect(event.mac).toBe('TEST')
+  })
+
+  test('emitAlert FATAL 走 mac=null', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    mockSocket.emit.mockClear()
+    ;(dtu as any).emitAlert({
+      mac: null,
+      type: 'FATAL',
+      message: '[process] startup: bind failed',
+      timestamp: Date.now()
+    })
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuAlert')
+    expect(calls.length).toBe(1)
+    const event = calls[0][1] as any
+    expect(event.mac).toBeNull()
+    expect(event.type).toBe('FATAL')
+  })
+
+  test('reason 字符串超 64 字符截断', () => {
+    const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    const longReason = 'a'.repeat(100)
+    ;(dtu as any).transition(DtuState.ONLINE, longReason)
+    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    const event = calls[0][1] as any
+    expect(event.reason.length).toBe(64)
+  })
+})

--- a/test/dtus/state.test.ts
+++ b/test/dtus/state.test.ts
@@ -1,0 +1,338 @@
+/**
+ * DtuState 状态机 + 健康度 + 重连退避 纯函数单测
+ *
+ * 跟老 RFC §12.6 测试矩阵 1:1 对齐
+ *   - DtuStateMachine: 8 个状态转换测试
+ *   - DtuHealth: 4 个健康度场景
+ *   - Reconnect Backoff: 3 个退避场景
+ *
+ * 0 mock，纯函数测试。
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  DtuState,
+  type DtuHealth,
+  computeHealth,
+  healthTier,
+  isValidTransition,
+  computeReconnectBackoff,
+  shouldReportHealth,
+  HEALTH_THRESHOLD_HEALTHY,
+  HEALTH_THRESHOLD_DEGRADED
+} from '../../src/dtus/state'
+
+// ======================== DtuStateMachine ========================
+
+describe('DtuState 转换合法性', () => {
+  test('初始 → CONNECTING 合法（用空字符串 from 表示初始）', () => {
+    expect(isValidTransition('' as any, DtuState.CONNECTING)).toBe(true)
+  })
+
+  test('CONNECTING → HANDSHAKING 合法（注册包解析成功）', () => {
+    expect(isValidTransition(DtuState.CONNECTING, DtuState.HANDSHAKING)).toBe(true)
+  })
+
+  test('CONNECTING → OFFLINE 合法（10s 无注册包）', () => {
+    expect(isValidTransition(DtuState.CONNECTING, DtuState.OFFLINE)).toBe(true)
+  })
+
+  test('HANDSHAKING → INITIALIZING 合法（5 条必查 AT 全过）', () => {
+    expect(isValidTransition(DtuState.HANDSHAKING, DtuState.INITIALIZING)).toBe(true)
+  })
+
+  test('HANDSHAKING → OFFLINE 合法（AT 查询超时）', () => {
+    expect(isValidTransition(DtuState.HANDSHAKING, DtuState.OFFLINE)).toBe(true)
+  })
+
+  test('INITIALIZING → ONLINE 合法', () => {
+    expect(isValidTransition(DtuState.INITIALIZING, DtuState.ONLINE)).toBe(true)
+  })
+
+  test('ONLINE → DEGRADED 合法（连续 3 次查询失败）', () => {
+    expect(isValidTransition(DtuState.ONLINE, DtuState.DEGRADED)).toBe(true)
+  })
+
+  test('DEGRADED → ONLINE 合法（连续 5 次查询成功）', () => {
+    expect(isValidTransition(DtuState.DEGRADED, DtuState.ONLINE)).toBe(true)
+  })
+
+  test('DEGRADED → DEGRADED 合法（连续失败但还没恢复，幂等）', () => {
+    expect(isValidTransition(DtuState.DEGRADED, DtuState.DEGRADED)).toBe(true)
+  })
+
+  test('ONLINE → RECONNECTING 合法（被动断开）', () => {
+    expect(isValidTransition(DtuState.ONLINE, DtuState.RECONNECTING)).toBe(true)
+  })
+
+  test('RECONNECTING → OFFLINE 合法（重试 5 次失败）', () => {
+    expect(isValidTransition(DtuState.RECONNECTING, DtuState.OFFLINE)).toBe(true)
+  })
+
+  test('ONLINE → RESTARTING 合法（AT+Z 触发）', () => {
+    expect(isValidTransition(DtuState.ONLINE, DtuState.RESTARTING)).toBe(true)
+  })
+
+  test('OFFLINE → ONLINE 不合法（不可恢复）', () => {
+    expect(isValidTransition(DtuState.OFFLINE, DtuState.ONLINE)).toBe(false)
+  })
+
+  test('CONNECTING → ONLINE 不合法（必须经 HANDSHAKING + INITIALIZING）', () => {
+    expect(isValidTransition(DtuState.CONNECTING, DtuState.ONLINE)).toBe(false)
+  })
+
+  test('8 个状态值都是 string', () => {
+    expect(Object.values(DtuState).length).toBe(8)
+    for (const v of Object.values(DtuState)) {
+      expect(typeof v).toBe('string')
+    }
+  })
+})
+
+// ======================== DtuHealth computeHealth ========================
+
+describe('computeHealth 纯函数', () => {
+  const now = 1_700_000_000_000  // 固定时间戳
+  const baseHealth: Omit<DtuHealth, 'score'> = {
+    lastCommAt: now,
+    consecutiveSuccesses: 0,
+    consecutiveFailures: 0,
+    queryTimeoutCount: 0,
+    totalRestarts: 0,
+    totalReconnects: 0,
+    signal: 20  // 强信号
+  }
+
+  test('初始 score = 100（最近通信 + 强信号 + 无失败 + 无重启）', () => {
+    expect(computeHealth(baseHealth, now)).toBe(100)
+  })
+
+  test('signal < 5 扣 20', () => {
+    const h = { ...baseHealth, signal: 3 }
+    expect(computeHealth(h, now)).toBe(80)
+  })
+
+  test('signal < 10 扣 10', () => {
+    const h = { ...baseHealth, signal: 8 }
+    expect(computeHealth(h, now)).toBe(90)
+  })
+
+  test('signal < 15 扣 5', () => {
+    const h = { ...baseHealth, signal: 12 }
+    expect(computeHealth(h, now)).toBe(95)
+  })
+
+  test('signal 0 扣 20（跟 < 5 一样）', () => {
+    const h = { ...baseHealth, signal: 0 }
+    expect(computeHealth(h, now)).toBe(80)
+  })
+
+  test('连续失败 1 次扣 10', () => {
+    const h = { ...baseHealth, consecutiveFailures: 1 }
+    expect(computeHealth(h, now)).toBe(90)
+  })
+
+  test('连续失败 4 次扣 40（max）', () => {
+    const h = { ...baseHealth, consecutiveFailures: 4 }
+    expect(computeHealth(h, now)).toBe(60)
+  })
+
+  test('连续失败 10 次还是 max -40（不重复扣）', () => {
+    const h = { ...baseHealth, consecutiveFailures: 10 }
+    expect(computeHealth(h, now)).toBe(60)
+  })
+
+  test('重启 1 次扣 5', () => {
+    const h = { ...baseHealth, totalRestarts: 1 }
+    expect(computeHealth(h, now)).toBe(95)
+  })
+
+  test('重启 4 次扣 20（max）', () => {
+    const h = { ...baseHealth, totalRestarts: 4 }
+    expect(computeHealth(h, now)).toBe(80)
+  })
+
+  test('60 分钟无通信扣 30（max -30, score 70）', () => {
+    // RFC §12.3: 每分钟无通信 -5, max -30 → 30 分钟后封顶扣 30
+    const h = { ...baseHealth, lastCommAt: now - 60 * 60 * 1000 }
+    expect(computeHealth(h, now)).toBe(70)
+  })
+
+  test('30 分钟无通信扣 30（max -30 封顶）', () => {
+    const h = { ...baseHealth, lastCommAt: now - 30 * 60 * 1000 }
+    expect(computeHealth(h, now)).toBe(70)
+  })
+
+  test('6 分钟无通信扣 30（封顶）', () => {
+    const h = { ...baseHealth, lastCommAt: now - 6 * 60 * 1000 }
+    expect(computeHealth(h, now)).toBe(70)
+  })
+
+  test('5 分钟无通信扣 25', () => {
+    const h = { ...baseHealth, lastCommAt: now - 5 * 60 * 1000 }
+    expect(computeHealth(h, now)).toBe(75)
+  })
+
+  test('复合扣分：弱信号 + 失败 + 重启 不会 < 0', () => {
+    const h = {
+      ...baseHealth,
+      lastCommAt: now - 60 * 60 * 1000,  // -30
+      signal: 0,                            // -20
+      consecutiveFailures: 10,              // -40
+      totalRestarts: 10                     // -20
+    }
+    expect(computeHealth(h, now)).toBe(0)
+  })
+
+  test('复合扣分：满 100 但不溢出', () => {
+    // 起点 100，扣 0 → 100
+    const h = {
+      ...baseHealth,
+      lastCommAt: now,
+      signal: 20,
+      consecutiveSuccesses: 5
+    }
+    expect(computeHealth(h, now)).toBe(100)
+  })
+})
+
+// ======================== healthTier ========================
+
+describe('healthTier 区间判定', () => {
+  test('score >= 80 → HEALTHY', () => {
+    expect(healthTier(80)).toBe('HEALTHY')
+    expect(healthTier(100)).toBe('HEALTHY')
+    expect(healthTier(95)).toBe('HEALTHY')
+  })
+
+  test('60-79 → MILD_DEGRADED', () => {
+    expect(healthTier(60)).toBe('MILD_DEGRADED')
+    expect(healthTier(75)).toBe('MILD_DEGRADED')
+    expect(healthTier(79)).toBe('MILD_DEGRADED')
+  })
+
+  test('40-59 → SEVERE_DEGRADED', () => {
+    expect(healthTier(40)).toBe('SEVERE_DEGRADED')
+    expect(healthTier(50)).toBe('SEVERE_DEGRADED')
+    expect(healthTier(59)).toBe('SEVERE_DEGRADED')
+  })
+
+  test('1-39 → CRITICAL', () => {
+    expect(healthTier(1)).toBe('CRITICAL')
+    expect(healthTier(20)).toBe('CRITICAL')
+    expect(healthTier(39)).toBe('CRITICAL')
+  })
+
+  test('0 → DEAD', () => {
+    expect(healthTier(0)).toBe('DEAD')
+  })
+
+  test('阈值常量：HEALTHY=80, DEGRADED=40', () => {
+    expect(HEALTH_THRESHOLD_HEALTHY).toBe(80)
+    expect(HEALTH_THRESHOLD_DEGRADED).toBe(40)
+  })
+})
+
+// ======================== Reconnect Backoff ========================
+
+describe('computeReconnectBackoff 退避算法', () => {
+  // 注入固定 random 让测试稳定
+  const fixedRandom = () => 0  // jitter = 0
+
+  test('第 1 次退避 1000ms (1s) + jitter', () => {
+    const r = computeReconnectBackoff({ attempt: 1, random: fixedRandom })
+    expect(r.shouldRetry).toBe(true)
+    expect(r.waitMs).toBe(1000)
+  })
+
+  test('第 2 次退避 2000ms (2s) + jitter', () => {
+    const r = computeReconnectBackoff({ attempt: 2, random: fixedRandom })
+    expect(r.waitMs).toBe(2000)
+  })
+
+  test('第 3 次退避 4000ms (4s) + jitter', () => {
+    const r = computeReconnectBackoff({ attempt: 3, random: fixedRandom })
+    expect(r.waitMs).toBe(4000)
+  })
+
+  test('第 4 次退避 8000ms (8s) + jitter', () => {
+    const r = computeReconnectBackoff({ attempt: 4, random: fixedRandom })
+    expect(r.waitMs).toBe(8000)
+  })
+
+  test('第 5 次退避 16000ms (16s) + jitter（max）', () => {
+    const r = computeReconnectBackoff({ attempt: 5, random: fixedRandom })
+    expect(r.waitMs).toBe(16000)
+  })
+
+  test('第 6 次 attempt > max(5) → shouldRetry=false', () => {
+    const r = computeReconnectBackoff({ attempt: 6, random: fixedRandom })
+    expect(r.shouldRetry).toBe(false)
+    expect(r.waitMs).toBe(0)
+  })
+
+  test('jitter 范围 [0, 500ms)', () => {
+    // random()=0.5 → jitter=250
+    const r = computeReconnectBackoff({ attempt: 1, random: () => 0.5 })
+    expect(r.waitMs).toBe(1250)
+  })
+
+  test('随机源 0.99 → 接近 max jitter', () => {
+    const r = computeReconnectBackoff({ attempt: 1, random: () => 0.99 })
+    // 1000 + 0.99 * 500 = 1000 + 495 = 1495
+    expect(r.waitMs).toBe(1495)
+  })
+
+  test('自定义 maxBackoffMs 截断（10s）', () => {
+    const r = computeReconnectBackoff({
+      attempt: 5,
+      maxBackoffMs: 10_000,
+      random: fixedRandom
+    })
+    // 16s 截到 10s
+    expect(r.waitMs).toBe(10_000)
+  })
+
+  test('自定义 maxAttempts（3）', () => {
+    const r1 = computeReconnectBackoff({ attempt: 3, maxAttempts: 3, random: fixedRandom })
+    expect(r1.shouldRetry).toBe(true)
+    const r2 = computeReconnectBackoff({ attempt: 4, maxAttempts: 3, random: fixedRandom })
+    expect(r2.shouldRetry).toBe(false)
+  })
+})
+
+// ======================== shouldReportHealth ========================
+
+describe('shouldReportHealth 60s 周期上报触发', () => {
+  test('ONLINE → true', () => {
+    expect(shouldReportHealth(DtuState.ONLINE)).toBe(true)
+  })
+
+  test('DEGRADED → true', () => {
+    expect(shouldReportHealth(DtuState.DEGRADED)).toBe(true)
+  })
+
+  test('CONNECTING → false', () => {
+    expect(shouldReportHealth(DtuState.CONNECTING)).toBe(false)
+  })
+
+  test('HANDSHAKING → false', () => {
+    expect(shouldReportHealth(DtuState.HANDSHAKING)).toBe(false)
+  })
+
+  test('INITIALIZING → false', () => {
+    expect(shouldReportHealth(DtuState.INITIALIZING)).toBe(false)
+  })
+
+  test('RECONNECTING → false', () => {
+    expect(shouldReportHealth(DtuState.RECONNECTING)).toBe(false)
+  })
+
+  test('RESTARTING → false', () => {
+    expect(shouldReportHealth(DtuState.RESTARTING)).toBe(false)
+  })
+
+  test('OFFLINE → false', () => {
+    expect(shouldReportHealth(DtuState.OFFLINE)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
RFC 002 PR #6（§12）：8 状态生命周期状态机 + 0-100 健康度评分 + 3 个新 Socket.IO 事件（`dtuState` / `dtuHealth` / `dtuAlert`），跟 server 端 agent 协调锁全 TS interface 字段。

## 新增
- **`src/dtus/state.ts`** (280 行, 纯函数层)
  - `DtuState` enum (8 选 1: CONNECTING / HANDSHAKING / INITIALIZING / ONLINE / DEGRADED / RECONNECTING / RESTARTING / OFFLINE)
  - `DtuHealth` 接口 (score + 7 个原始指标)
  - `computeHealth(h, now)` 纯函数 (RFC §12.3 算法, 0-100, 含信号弱/连续失败/重启次数扣分)
  - `healthTier(score)` 5 区间判定 (HEALTHY / MILD_DEGRADED / SEVERE_DEGRADED / CRITICAL / DEAD)
  - `VALID_TRANSITIONS` Set + `isValidTransition(from, to)` (RFC §12.2 转换表)
  - `DtuAlert` 接口 + `AlertType` 4 类 (AT_TIMEOUT / INVALID_REGISTER / PROFILE_CACHE_FAIL / FATAL)
  - `computeReconnectBackoff()` (RFC §12.5 退避 1s/2s/4s/8s/16s + jitter, 5 次后转 OFFLINE)
  - `HEALTH_REPORT_INTERVAL_MS = 60_000` + `shouldReportHealth(state)`
- **`src/dtus/base.ts`** (+143 行 集成)
  - `state: DtuState` 字段 (默认 HANDSHAKING) + `health: DtuHealth` 字段
  - `transition(to, reason)` 方法: 合法性检查 + 幂等 + emit dtuState + 启停 60s 上报 + reason 截断 64 字符
  - `emitHealth()` 60s 周期 (ONLINE/DEGRADED 触发)
  - `emitAlert(alert)` 4 类告警统一入口
  - `bindSocket`: initialize 成功 → transition ONLINE；失败 → AT_TIMEOUT alert + OFFLINE
  - `bindSocket`: socket close → transition OFFLINE + 停 60s 上报

## 新增测试 (66 spec)
- **`test/dtus/state.test.ts`** (55 test, 纯函数 0 mock)
  - DtuStateMachine 转换合法性: 15 test
  - computeHealth: 14 test (起点 100 + signal 4 档 + 失败 3 档 + 重启 2 档 + 通信 4 档 + 复合 2 档)
  - healthTier: 7 test
  - ReconnectBackoff: 10 test
  - shouldReportHealth: 9 test
- **`test/dtus/integration.test.ts`** (11 test, mock socket)
  - 状态机集成: 7 test (初始 / transition / 幂等 / 不合法静默 / initialize 成功 / initialize 失败 alert / socket close)
  - emitHealth / emitAlert: 4 test (ONLINE 触发 / AT_TIMEOUT / FATAL mac=null / reason 64 字符截断)

## 3 个新 Socket.IO 事件 TS interface (已跟 server 端 agent 锁全)

```ts
interface DtuStateEvent {
  mac: string
  from: DtuState  // 8 选 1
  to: DtuState
  score: number   // 0-100
  reason: string  // ≤ 64 字符, 不能为空 (cairui 拍板)
  timestamp: number
}

interface DtuHealthEvent {
  mac: string
  score: number
  health: {
    lastCommAt: number
    consecutiveSuccesses: number
    consecutiveFailures: number
    queryTimeoutCount: number
    totalRestarts: number
    totalReconnects: number
    signal: number  // 0-31
  }
  timestamp: number
}

interface DtuAlertEvent {
  mac: string | null  // INVALID_REGISTER / FATAL 时为 null
  type: 'AT_TIMEOUT' | 'INVALID_REGISTER' | 'PROFILE_CACHE_FAIL' | 'FATAL'
  message: string
  context?: Record<string, unknown>
  timestamp: number
}
```

**server 端 zod schema 严格对齐上述字段名**（不加重前缀 `mq_` / `log_` 等）。

## RFC 修订建议 (server 端 agent 将提)
RFC §12.3 算法（每分钟 -5 max -30）跟 §12.6 测试矩阵（"60 分钟 score 归零"）内部矛盾。本 PR 按 §12.3 算法落地，test 改用例为 "60 分钟无通信扣 30 (max, score=70)"。建议 server 端在提 RFC 修订时同步标注。

## RFC §12.2 转换表补充
**HANDSHAKING → ONLINE** 不在 RFC 原文，是本 PR 新增的合法转换（`VALID_TRANSITIONS` 加一行）。理由：CellularDtu.initialize() 一次性查 8 条 AT 完成（PR #4 字面行为），不显式走 INITIALIZING 中间态。`INITIALIZING → ONLINE` 留给未来 §11.7 分层落地时用。

## Test plan
- [x] 66 新增 spec 全过（55 state + 11 integration）
- [x] 195/198 全测 pass（3 fail 是 `uploader.test.ts` pre-existing）
- [x] `bun --check` 全绿
- [ ] **staging 24h 真机回归**（AGENTS.md 强约束）
  - 状态转换 log 顺序符合 RFC §12.2 转换表
  - dtuState / dtuHealth / dtuAlert 事件按预期触发
  - ONLINE/DEGRADED 启 60s 上报，其它状态停
  - DTU 首次连接 / 重连 / 主动重启 / socket close 路径行为 1:1 兼容

## 跨项目协调
- server 端 agent 已 ack 4 决策 + mac=null dedup key 设计 + 3 个 TS interface 字段对齐
- server 端准备开 `feat/rf002-pr6-state-health-alert` 跟 main 拉，timeline PR merge main 后启动
- Node 端 PR #6 落 main 后 server 端 PR 一起发，staging 24h 一起回归

🤖 Generated with [MiniMax-M3](https://github.com/wgcairui/uart-node)