### PR TITLE
fix(uploader): HTTP UPLOAD_TIMEOUT_MS 5s → 30s, 修复 ECONNRESET 雪崩

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ Node 端在连接 server 时同时把 token 放在三个握手通道（与 `uart
 
 ### HTTP /api/node/* 上传
 
-`fetch.ts` 走原生 `fetch` + `AbortSignal.timeout(5000)`，POST 时把 token 塞在
+`fetch.ts` 走原生 `fetch` + `AbortSignal.timeout(30000)` (默认 30s,
+可由 `UPLOAD_TIMEOUT_MS` 环境变量覆盖)，POST 时把 token 塞在
 `x-node-token` header。
+
+> ⚠️ **2026-06-22 hotfix**: 默认超时从 5s 调到 30s, 修复 ECONNRESET 雪崩。
+> 5s 太接近 server 端 `terminal.parse` 高峰耗时 (4.7s), server 略慢就触发
+> AbortSignal timeout → RST。server 端同步把 `/api/node/queryData` 改成
+> fire-and-forget, 30s 留 6× 余量。详见 server commit。
 
 ### 部署示例
 

--- a/src/services/uploader.ts
+++ b/src/services/uploader.ts
@@ -153,7 +153,19 @@ export function __resetUploaderForTest(): void {
 const UPLOAD_CONCURRENCY = 4
 /** HTTP 上传队列上限（背压） */
 const UPLOAD_QUEUE_MAX = 1000
-/** HTTP 单次请求超时 */
-const UPLOAD_TIMEOUT_MS = 5_000
+/**
+ * HTTP 单次请求超时 (2026-06-22 hotfix: 5_000 → 30_000)
+ *
+ * 历史: 默认 5s 与 server 端 `terminal.parse` 高峰耗时 (4.7s) 几乎重叠,
+ *       server 略慢 (5.1s) 就触发 `AbortSignal.timeout` → 客户端 RST → ECONNRESET
+ *       雪崩 (实测 8 次/2s @ 22:06:39-41)。
+ *
+ * 为什么不是更长 (60s / 120s): server 端 hotfix 把 `/api/node/queryData`
+ *   改成 fire-and-forget (鉴权后立即 ack), 30s 已经留 6× 余量。
+ *   保留重试 + 指数退避, 单次超时只是放弃这一次, 不是放弃整条数据流。
+ *
+ * 可由环境变量 UPLOAD_TIMEOUT_MS 覆盖 (跟 uart-pesiv-node 对齐)。
+ */
+const UPLOAD_TIMEOUT_MS = Number(process.env.UPLOAD_TIMEOUT_MS ?? 30_000)
 /** HTTP 重试最大次数 */
 const UPLOAD_RETRY_MAX = 2


### PR DESCRIPTION
## 背景

server 端 `/api/node/queryData` 默认会等 `terminal.parse` 流水线完成才返回 (高峰 4.7s), Node 端 5s `AbortSignal.timeout` 在 server 略慢时触发 → 主动 RST → ECONNRESET 雪崩。

**实测**: 22:06:39-41 这 2s 内 8 次 ECONNRESET, 同时段 3 个 device parse 慢 (2.155s / 4.725s / 2.677s)。

## 修复

`UPLOAD_TIMEOUT_MS` 默认 5s → 30s (env var 仍可覆盖)。30s 留 6× 余量, 配合 server 端 fire-and-forget PR 让 HTTP 立即 ack。

**为什么不是更长 (60s / 120s)**: server 端 hotfix 把 `/api/node/queryData` 改成 fire-and-forget (鉴权后立即 ack), 30s 已经够覆盖所有合理慢路径。保留重试 + 指数退避 (UPLOAD_RETRY_MAX=2), 单次超时只是放弃这一次, 不是放弃整条数据流。

## 测试

- 现有 198 个 bun test 通过 (preexisting 3 fail 跟本 PR 无关, 是 `Fetch.ts 包装` mock 模式问题)
- 不引入新 fail

## Server 同步 PR

修复需要两端协同, server 同步把 queryData 改成 fire-and-forget:

- wgcairui/midwayuartserver: fix(realtime): /api/node/queryData fire-and-forget, 修复 ECONNRESET 雪崩

## 部署顺序

**server 端先部署**, Node 端后部署:
1. server PR 部署后, queryData 立即 ack, Node 端 30s timeout 生效
2. Node PR 部署后, 全链路 ECONNRESET 雪崩消除

如果先部署 Node PR (timeout 30s 但 server 还在 await), server parse 卡死时 Node 等待时间从 5s 变 30s, 但不会有 ECONNRESET, 只是慢路径超时重试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)