### PR TITLE
fix(dtus): reConnectSocket 3 步 recovery + invalid transition 不静默 (PR #12 hotfix)

### DIFF
--- a/src/dtus/base.ts
+++ b/src/dtus/base.ts
@@ -126,9 +126,17 @@ export abstract class Dtu {
     const from = this.state
     // 幂等检查
     if (from === to) return
-    // 合法性检查（不合法静默忽略, 老 client.ts 没显式状态机，宽松行为）
+    // 合法性检查（PR #12 hotfix: 升级到 console.error + emit INVALID_STATE_TRANSITION alert, 不再静默忽略）
+    // 8 天 staging 回归暴露 dtuStateLatest = 0 根因之一: transition() 静默 + warn 长期让 observability 断
+    // 部署后 7d TTL sweep + Node bug 叠加才被发现, 太晚. server 端 PR A 下个 sprint 接 log.terminalEvents
     if (!isValidTransition(from, to)) {
-      console.warn(`[Dtu ${this.mac}] invalid transition: ${from} -> ${to} (reason: ${reason})`)
+      console.error(`[Dtu ${this.mac}] invalid transition: ${from} -> ${to} (reason: ${reason})`)
+      this.emitAlert({
+        mac: this.mac,
+        type: 'INVALID_STATE_TRANSITION',
+        message: `[dtu] state machine: invalid transition ${from} -> ${to} (reason: ${reason})`,
+        timestamp: Date.now()
+      })
       return
     }
     // 更新 state
@@ -292,6 +300,15 @@ export abstract class Dtu {
    */
   public reConnectSocket(socket: Socket): void {
     this.socketsb = new socketsb(socket, this.mac)
+    // PR #12 hotfix: 3 步 recovery (offline → handshaking → initializing → online)
+    // bindSocket 内部 initialize() 完 transition(ONLINE, 'initialize_ok') — 我们先到 INITIALIZING
+    // 8 天 staging 回归暴露: 之前 reConnectSocket 不重置 state, OFFLINE → ONLINE invalid
+    //   transition() 静默忽略 (PR #6 当时 console.warn + return), dtuState 事件不 emit,
+    //   server 端 dtuStateLatest 永远不更新 (叠加 7d TTL sweep 数据清空).
+    // OFFLINE → HANDSHAKING 跳过 CONNECTING (reConnectSocket 不重跑 sniffer, 直接进注册路径)
+    // 3 步 recovery 跟 initial connect 路径一致 (default state = HANDSHAKING 那套), observability 完整
+    this.transition(DtuState.HANDSHAKING, 'reconnect')
+    this.transition(DtuState.INITIALIZING, 'reconnect')
     this.bindSocket(this.socketsb.getSocket())
     // 判断是否是主动断开
     if (this.reboot) {

--- a/src/dtus/state.ts
+++ b/src/dtus/state.ts
@@ -189,7 +189,12 @@ const VALID_TRANSITIONS = new Set<string>([
   'RECONNECTING->OFFLINE',
   'RESTARTING->OFFLINE',
   // 任何状态 → RESTARTING（AT+Z 触发）
-  'INITIALIZING->RESTARTING'
+  'INITIALIZING->RESTARTING',
+  // PR #12 hotfix: OFFLINE 是 terminal state, 但 reConnectSocket 需要 recovery 路径
+  // 之前漏: OFFLINE 不在 VALID_TRANSITIONS, transition(OFFLINE → ONLINE) 静默忽略
+  // 8 天 staging 回归暴露 dtuStateLatest = 0 根因之一
+  // OFFLINE → HANDSHAKING 跳过 CONNECTING (reConnectSocket 不重跑 sniffer, 直接进注册)
+  'OFFLINE->HANDSHAKING'
 ])
 
 /**
@@ -200,18 +205,28 @@ export function isValidTransition(from: DtuState, to: DtuState): boolean {
   return VALID_TRANSITIONS.has(`${from}->${to}`)
 }
 
-// ======================== 4 类 AlertType ========================
+// ======================== 5 类 AlertType (PR #12 hotfix) ========================
 
 /**
- * 4 个告警类型（cairui 2026-06-15 拍板）
+ * 5 个告警类型（cairui 2026-06-15 拍板 4 类 + 2026-06-26 hotfix 增 INVALID_STATE_TRANSITION）
  *
  * 触发位置（RFC §12.4.2）：
  *   - AT_TIMEOUT: client.run() 连续 3 次 AT 查询超时（src/dtus/base.ts:queryInstruct）
  *   - INVALID_REGISTER: sniff register 包解析失败（src/server/tcp-server.ts:onConnection）
  *   - PROFILE_CACHE_FAIL: /api/node/dtu-info-cache GET/POST 连续 5 次失败（PR #7 落地）
  *   - FATAL: 进程级 fatal（main.ts catch，mac: null）
+ *   - INVALID_STATE_TRANSITION: state machine 非法转换（src/dtus/base.ts:transition, PR #12 hotfix）
+ *
+ * PR #12 hotfix 背景: 8 天 staging 回归暴露 dtuStateLatest = 0 (TTL 7d 自然过期 + Node bug 叠加),
+ *   transition() 静默忽略 invalid + console.warn 导致 observability 断。
+ *   升级到 console.error + emit alert, 让 server 下个 sprint PR A 落库可见。
  */
-export type AlertType = 'AT_TIMEOUT' | 'INVALID_REGISTER' | 'PROFILE_CACHE_FAIL' | 'FATAL'
+export type AlertType =
+  | 'AT_TIMEOUT'
+  | 'INVALID_REGISTER'
+  | 'PROFILE_CACHE_FAIL'
+  | 'FATAL'
+  | 'INVALID_STATE_TRANSITION'
 
 /**
  * DtuAlert payload（RFC §12.4）

--- a/src/protocol/events.ts
+++ b/src/protocol/events.ts
@@ -148,12 +148,13 @@ export interface DtuHealthEvent {
   timestamp: number
 }
 
-/** dtuAlert 事件 4 类枚举（cairui 拍板 2026-06-15） */
+/** dtuAlert 事件 5 类枚举（cairui 拍板 2026-06-15 4 类 + 2026-06-26 PR #12 hotfix 增 INVALID_STATE_TRANSITION） */
 export type AlertType =
-  | 'AT_TIMEOUT'         // §3.7.4: AT 连续 3 次超时
-  | 'INVALID_REGISTER'   // §3.7.4: 非注册包连接（mac: null）
-  | 'PROFILE_CACHE_FAIL' // §3.7.4: profile cache 拉/写连续 5 次失败
-  | 'FATAL'              // §3.7.4: 进程级 fatal（main 兜底, mac: null）
+  | 'AT_TIMEOUT'                  // §3.7.4: AT 连续 3 次超时
+  | 'INVALID_REGISTER'            // §3.7.4: 非注册包连接（mac: null）
+  | 'PROFILE_CACHE_FAIL'          // §3.7.4: profile cache 拉/写连续 5 次失败
+  | 'FATAL'                       // §3.7.4: 进程级 fatal（main 兜底, mac: null）
+  | 'INVALID_STATE_TRANSITION'    // §12.4.2: state machine 非法转换 (PR #12 hotfix, 8 天 staging 回归暴露)
 
 /** dtuAlert 事件 payload（FATAL 走 dtuAlert 不抽 alarm, 5min 去重, cairui 拍板） */
 export interface DtuAlertEvent {

--- a/test/dtus/integration.test.ts
+++ b/test/dtus/integration.test.ts
@@ -170,18 +170,35 @@ describe('Dtu 基类 — 状态机集成', () => {
     expect(calls.length).toBe(0)
   })
 
-  test('transition 不合法 → 静默忽略', () => {
+  test('transition 不合法 → console.error + emit INVALID_STATE_TRANSITION alert (PR #12 hotfix)', () => {
+    // PR #12 hotfix: invalid transition 不再静默忽略, 升级到 console.error + emit alert
+    //   8 天 staging 回归暴露根因之一. server 端 PR A 下个 sprint 接 log.terminalEvents
     const dtu = new TestDtu(makeMockSocket(), 'TEST')
+    // spy console.error
+    const consoleSpy = spyOn(console, 'error').mockImplementation(() => {})
     // 初始 HANDSHAKING → ONLINE 是合法的，转一次
     ;(dtu as any).transition(DtuState.ONLINE, 'init')
     mockSocket.emit.mockClear()
     // OFFLINE → ONLINE 不合法（OFFLINE 是终态）
     ;(dtu as any).transition(DtuState.OFFLINE, 'force')  // OFFLINE 合法
     ;(dtu as any).transition(DtuState.ONLINE, 'invalid_back')  // OFFLINE → ONLINE 不合法
-    const calls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
-    // 只应该有 ONLINE → OFFLINE 一次，OFFLINE → ONLINE 静默忽略
-    expect(calls.length).toBe(1)
-    expect(calls[0][1].to).toBe(DtuState.OFFLINE)
+    // dtuState 仍只 emit ONLINE → OFFLINE 一次（OFFLINE → ONLINE 不合法不 emit dtuState）
+    const stateCalls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
+    expect(stateCalls.length).toBe(1)
+    expect(stateCalls[0][1].to).toBe(DtuState.OFFLINE)
+    // 但 emit INVALID_STATE_TRANSITION dtuAlert 一次
+    const alertCalls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuAlert')
+    expect(alertCalls.length).toBe(1)
+    const alert = alertCalls[0][1] as any
+    expect(alert.type).toBe('INVALID_STATE_TRANSITION')
+    expect(alert.mac).toBe('TEST')
+    expect(alert.message).toContain('OFFLINE -> ONLINE')
+    expect(alert.message).toContain('invalid_back')
+    // console.error 被调一次
+    expect(consoleSpy).toHaveBeenCalled()
+    const errMsg = String(consoleSpy.mock.calls[0][0])
+    expect(errMsg).toContain('invalid transition')
+    consoleSpy.mockRestore()
   })
 
   test('initialize 成功 → transition ONLINE', async () => {
@@ -228,6 +245,39 @@ describe('Dtu 基类 — 状态机集成', () => {
     const stateCalls = mockSocket.emit.mock.calls.filter(c => c[0] === 'dtuState')
     const offlineCall = stateCalls.find(c => (c[1] as any).to === DtuState.OFFLINE)
     expect(offlineCall).toBeDefined()
+  })
+
+  test('reConnectSocket 3 步 recovery: OFFLINE → HANDSHAKING → INITIALIZING → ONLINE (PR #12 hotfix)', async () => {
+    // PR #12 hotfix: 之前 reConnectSocket 不重置 state, OFFLINE → ONLINE invalid 静默忽略,
+    //   dtuState 事件不 emit, server 端 dtuStateLatest 永远不更新 (8 天 staging 回归暴露)
+    // 现在走 3 步 recovery (OFFLINE → HANDSHAKING → INITIALIZING → ONLINE),
+    // 跳过 CONNECTING (reConnectSocket 不重跑 sniffer, 直接进注册路径)
+    const sock = makeMockSocket()
+    const dtu = new TestDtu(sock, 'TEST')
+    await new Promise(r => setImmediate(r))
+    // 初始连接 HANDSHAKING → ONLINE
+    expect((dtu as any).state).toBe(DtuState.ONLINE)
+    // 触发 socket close → OFFLINE
+    sock.emit('close')
+    await new Promise(r => setImmediate(r))
+    expect((dtu as any).state).toBe(DtuState.OFFLINE)
+    mockSocket.emit.mockClear()
+    // 模拟重连: 调 reConnectSocket
+    const newSock = makeMockSocket()
+    dtu.reConnectSocket(newSock)
+    await new Promise(r => setImmediate(r))
+    // 3 步 recovery 全 emit: HANDSHAKING / INITIALIZING / ONLINE
+    // (OFFLINE → HANDSHAKING 由 reConnectSocket 触发, HANDSHAKING → INITIALIZING 跟 INITIALIZING → ONLINE 由 bindSocket 内部触发)
+    const stateCalls = mockSocket.emit.mock.calls
+      .filter(c => c[0] === 'dtuState')
+      .map(c => (c[1] as any).to as DtuState)
+    expect(stateCalls).toEqual([
+      DtuState.HANDSHAKING,
+      DtuState.INITIALIZING,
+      DtuState.ONLINE
+    ])
+    // 终态 ONLINE
+    expect((dtu as any).state).toBe(DtuState.ONLINE)
   })
 })
 

--- a/test/dtus/state.test.ts
+++ b/test/dtus/state.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   DtuState,
   type DtuHealth,
+  type AlertType,
   computeHealth,
   healthTier,
   isValidTransition,
@@ -86,6 +87,34 @@ describe('DtuState 转换合法性', () => {
     for (const v of Object.values(DtuState)) {
       expect(typeof v).toBe('string')
     }
+  })
+})
+
+// ======================== AlertType 5 类 (PR #12 hotfix) ========================
+
+describe('AlertType 5 类枚举 (PR #12 hotfix)', () => {
+  // PR #12 hotfix: 加 INVALID_STATE_TRANSITION 第 5 类 alert
+  // 8 天 staging 回归暴露: transition() 静默忽略 invalid + console.warn 长期让 observability 断
+  // 升级到 console.error + emit alert, server 端 PR A 下个 sprint 接 log.terminalEvents
+  test('5 类 alert 字符串赋值合法', () => {
+    const alerts: AlertType[] = [
+      'AT_TIMEOUT',
+      'INVALID_REGISTER',
+      'PROFILE_CACHE_FAIL',
+      'FATAL',
+      'INVALID_STATE_TRANSITION'
+    ]
+    expect(alerts.length).toBe(5)
+    for (const a of alerts) {
+      expect(typeof a).toBe('string')
+      expect(a.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('INVALID_STATE_TRANSITION 字符串格式正确', () => {
+    // 用 as const 验证 TypeScript 类型可赋值
+    const a: AlertType = 'INVALID_STATE_TRANSITION'
+    expect(a).toBe('INVALID_STATE_TRANSITION')
   })
 })
 


### PR DESCRIPTION
## 背景

8 天 staging 回归 (06-18 → 06-26) 暴露 `log.dtuStateLatest` 从 17 跌到 0 文档, 同期 DTU_HEALTH_SAMPLE 持续涨 (121K). 跟 server agent 联合 diagnose 锁定**双因素根因**:

1. **TTL 7d 自然过期 (主)**: `log.dtuStateLatest` 是 regular collection, 有 `createdAt` 7d TTL 字段. 06-18 + 7d = 06-25 sweep 干净. server handler 完好, 不回滚.
2. **Node 端 reConnectSocket 不发 dtuState (叠加)**: PR #6 (commit 8fb370e) 漏修 `reConnectSocket` 不重置 state, OFFLINE → ONLINE 不在 VALID_TRANSITIONS. 静默忽略 + console.warn, dtuState 事件不 emit, server 端 dtuStateLatest 永远不更新.

参考:
- server agent 输入: PR #55/59/60 timeseries 累积 19 collection
- 8 天 staging 回归 staging-5h-watch cron 在 06-18 15:55:21 auto-expire 之后没重启

## 修复

### 1. `reConnectSocket` 3 步 recovery

`src/dtus/base.ts` 开头加 2 个 transition (OFFLINE → HANDSHAKING → INITIALIZING), bindSocket 内部 initialize() 完 transition(ONLINE, 'initialize_ok') 是最后一步. 跳过 CONNECTING 因为 reConnectSocket 不重跑 sniffer, 直接进注册路径.

```ts
public reConnectSocket(socket: Socket): void {
  this.socketsb = new socketsb(socket, this.mac)
  // PR #12 hotfix: 3 步 recovery
  this.transition(DtuState.HANDSHAKING, 'reconnect')
  this.transition(DtuState.INITIALIZING, 'reconnect')
  this.bindSocket(this.socketsb.getSocket())
  ...
}
```

### 2. `VALID_TRANSITIONS` 加 `OFFLINE->HANDSHAKING`

`src/dtus/state.ts` VALID_TRANSITIONS 收尾加 1 项, 让 recovery 路径合法:

```ts
// PR #12 hotfix: OFFLINE 是 terminal state, 但 reConnectSocket 需要 recovery 路径
'OFFLINE->HANDSHAKING'
```

### 3. `transition()` invalid 路径升级

`src/dtus/base.ts` invalid transition 静默忽略 + console.warn → console.error + emit dtuAlert type='INVALID_STATE_TRANSITION' (新增第 5 类 alert). server 端 PR A 下个 sprint 接 log.terminalEvents.

### 4. `AlertType` 加第 5 类 (state.ts + events.ts 双份)

```ts
export type AlertType =
  | 'AT_TIMEOUT'
  | 'INVALID_REGISTER'
  | 'PROFILE_CACHE_FAIL'
  | 'FATAL'
  | 'INVALID_STATE_TRANSITION'  // PR #12 hotfix
```

## 测试

`bun test` 198 pass (was 195, +3 new):
- 2 AlertType 5 类枚举测试 (state.test.ts)
- 1 reConnectSocket 3 步 recovery 测试 (integration.test.ts)
- 1 invalid transition 升级测试 (integration.test.ts, 改写原"静默忽略"test)

3 preexisting fail 跟本 PR 无关: `uploader.test.ts` Fetch.ts 包装 mock 模式问题 (PR #11 提过).

## 部署 plan (cairui 拍 B2 异步)

1. **本 PR (Node 端)** — 现在 merge + 部署 staging
2. **Server PR A (INVALID_STATE_TRANSITION 接收)** — 下个 sprint, server agent 等 cairui 拍
3. **Server PR B (dtuStateEventTotal metric Counter)** — 下个 sprint, 不催

中间观察窗 console-only: Node 端 console.error + dtuAlert emit 出来, 但 server 端 dtu-event.schema.ts 没 INVALID_STATE_TRANSITION enum, handler 走 `if (!kind) return` 静默丢. staging 16 DTU 验证:
- `log.dtuStateLatest` 恢复增长 (重连时 3 events / DTU)
- `log.terminalEvents` ALERT_INVALID_STATE_TRANSITION 暂不出现 (server PR A 之后激活)
- console.error 在 uartnode log 暴露

## 关联

- agent memory: "State machine invalid transition 必须显式上报, 不能静默忽略" (2026-06-26)
- agent memory: "reConnectSocket 必须重置 state, 不能复用 OFFLINE" (2026-06-26)
- agent memory: "staging 8 天回归暴露 TTL + Node bug 双因素" (2026-06-26)
