### PR TITLE
feat: docs sync v4 + soft-dtu skeleton + webview framework

### DIFF
--- a/.harness/docs/architecture/data-flow.md
+++ b/.harness/docs/architecture/data-flow.md
@@ -1,6 +1,9 @@
 # 数据流
 
 > 三个外部世界之间的数据通路：DTU ↔ UartNode ↔ uart-server
+>
+> **v4 sync 2026-07-14**：v4 重构（RFC 002 PR #1-#12）落地后文件路径变了，本文件 v1 引用老 `client.ts:75` 等
+> 行号已 stale。下表用 v4 新路径（`dtus/cellular.ts` / `dtus/base.ts` / `server/tcp-server.ts` 等）。
 
 ## 1. 端到端时序
 
@@ -12,19 +15,30 @@
    │                        │───────── 'register' (NodeInfo) ────►
    │                        │◄────── 'registerSuccess' (config) ─┤
    │                        │   → new TcpServer(conf)            │
+   │                        │   → tcpServer.listen()             │
    │                        │                                    │
    │ TCP connect            │                                    │
    ├───────────────────────►│                                    │
    │                        │ 10s 推 AT 仪式 (4G 专属)            │
-   │◄────── +++AT+... ─────┤                                    │
+   │                        │   server/register-handler.ts       │
+   │                        │   :pushCellularRegisterInvite     │
+   │◄──── +++AT+NREGEN=... ─┤                                    │
+   │◄──── +++AT+NREGDT=... ─┤                                    │
    │                        │                                    │
    │ 注册包 (4G 专属)        │                                    │
-   ├────── register&... ───►│                                    │
-   │                        │ new Client / 监听 socket           │
+   ├──── register&... ─────►│                                    │
+   │                        │ server/tcp-server.ts:onConnection  │
+   │                        │   → CellularSniffer.match          │
+   │                        │   → CellularRegisterHandler.handle │
+   │                        │   → new CellularDtu(socket, mac)  │
+   │                        │     = new Dtu extends CellularDtu │
+   │                        │   → macSocketMaps.set(mac, dtu)   │
+   │                        │                                    │
    │                        │ 'terminalOn' (mac, false)          │
    │                        ├──────────────── 'terminalOn' ──────►
    │                        │                                    │
-   │                        │ run() → 批量查 AT (4G 专属)        │
+   │                        │ CellularDtu.initialize()           │
+   │                        │  → 8 条 AT 批量查 (4G 专属)         │
    │◄─── +++AT+PID ────────┤                                    │
    │──── +ok=... ──────────►│                                    │
    │   ... × 8 ...          │                                    │
@@ -35,66 +49,75 @@
    │       透传数据          │                                    │
    │◄═══════════════════════╪════════════════════════════════════ │
    │                        │                                    │
-   │                        │                                    │
    │                        │           server 主动查询            │
    │                        │◄──── 'query' (QueryInstruct) ───────┤
-   │                        │ tcpServer.Bus()                    │
+   │                        │ tcpServer.bus('QueryInstruct', Q)  │
    │                        │   ↓                                │
+   │                        │ dtus/base.ts:Dtu.saveCache(Q)      │
    │                        │ socketsb.write('指令\r')            │
    │◄──── 指令 ─────────────┤                                    │
    │──── 响应 ─────────────►│                                    │
-   │                        │ fetch.queryData(result)             │
+   │                        │ services/uploader.ts:enqueue       │
+   │                        │  → 'queryData'                     │
    │                        ├──────────────── 'queryData' ───────►
    │                        │                                    │
    │                        │                                    │
 ```
 
-## 2. 五个外部事件
+## 2. 五个外部事件（v4 不变）
 
 | 方向 | 事件 | 触发方 | UartNode 入口 | 出口 |
 |---|---|---|---|---|
-| **Server → Node** | `registerSuccess` | server | `IOClient.on('registerSuccess')` (`main.ts:20`) | 启 TcpServer |
-| **Server → Node** | `query` | server | `IOClient.on('query')` (`main.ts:31`) | 派发到 Client 缓存 |
-| **Server → Node** | `instructQuery` | server | `IOClient.on('instructQuery')` (`main.ts:37`) | 同上 |
-| **Server → Node** | `DTUoprate` | server | `IOClient.on('DTUoprate')` (`main.ts:42`) | 同上 |
-| **Server → Node** | `nodeInfo` | server | `IOClient.on('nodeInfo')` (`main.ts:47`) | `fetch.nodeInfo` |
+| **Server → Node** | `registerSuccess` | server | `IOClient.on('registerSuccess')` (`main.ts`) | 启 TcpServer |
+| **Server → Node** | `query` | server | `IOClient.on('query')` (`main.ts`) | 派发到 Dtu 缓存 |
+| **Server → Node** | `instructQuery` | server | `IOClient.on('instructQuery')` (`main.ts`) | 同上 |
+| **Server → Node** | `DTUoprate` | server | `IOClient.on('DTUoprate')` (`main.ts`) | 同上 |
+| **Server → Node** | `nodeInfo` | server | `IOClient.on('nodeInfo')` (`main.ts`) | `fetch.nodeInfo` |
 
-## 3. 六个 Node 主动事件
+## 3. Node 主动事件（v4 新增 3 个）
 
-| 事件 | 触发点 | 数据 | 用途 |
+| 事件 | 触发点（v4）| 数据 | 用途 |
 |---|---|---|---|
-| `register` | `main.ts:17` | `tool.NodeInfo()` | node 上线注册 |
-| `ready` | `main.ts:69` (10s 后) | — | 告知 server 设备已就绪 |
-| `terminalOn` | `client.ts:75` 等 | `(mac, forceReport)` | 设备上线 |
-| `terminalOff` | `client.ts:108` | `(mac, forceReport)` | 设备离线 |
-| `busy` | `client.ts:312, 115` | `(mac, busy, count)` | 设备查询堆积状态 |
-| `result` | `IO.ts:66` | `(eventName, data)` | 响应 server 的 `ioOnResult` 触发 |
-| `deviceopratesuccess` | `client.ts:440` | `(Query.events, result)` | 操作指令完成 |
-| `dtuopratesuccess` | `client.ts:461` | `(Query.events, result)` | AT 指令完成 |
+| `register` | `main.ts` | `services/dtu-info.ts:nodeInfo()` | node 上线注册 |
+| `ready` | `main.ts` (10s 后) | — | 告知 server 设备已就绪 |
+| `terminalOn` | `dtus/base.ts:Dtu` constructor / `reConnectSocket` | `(mac, reline)` | 设备上线 / 重连（reline=true 主动断开）|
+| `terminalOff` | `dtus/base.ts:Dtu.bindSocket` close | `(mac, force)` | 设备离线 |
+| `busy` | `dtus/base.ts:Dtu.processingQueue` | `(mac, busy, count)` | 设备查询堆积状态 |
+| `result` | `IO.ts:ioOnResult` 模式 | `(eventName, data)` | 响应 server 的 `ioOnResult` 触发 |
+| `deviceopratesuccess` | `dtus/base.ts:Dtu.oprateParse` | `(query.events, result)` | 操作指令完成 |
+| `dtuopratesuccess` | `dtus/base.ts:Dtu.atParse` | `(query.events, result)` | AT 指令完成 |
+| **`dtuState`** (v4 新) | `dtus/base.ts:Dtu.transition` | `{mac, from, to, score, reason, timestamp}` | 状态转换，latest-wins 覆盖 |
+| **`dtuHealth`** (v4 新) | `dtus/base.ts:Dtu.emitHealth` 60s 周期 | `{mac, score, health, timestamp}` | 健康度上报，ONLINE/DEGRADED 才发 |
+| **`dtuAlert`** (v4 新) | `dtus/base.ts:Dtu.emitAlert` | `{mac, type, message, context?, timestamp}` | 4 类告警（+INVALID_STATE_TRANSITION）|
 
-外加 `terminalMountDevTimeOut` / `terminalMountDevTimeOutRestore` / `instructTimeOut` /
-`instructOprate` —— 异常/告警事件。
+外加 `terminalMountDevTimeOut` / `instructTimeOut` —— 异常/告警事件。
 
 ## 4. 上行 HTTP 路径（**与 Socket.IO 平行**）
 
-| 路径 | 触发 | 数据 |
+| 路径 | 触发（v4）| 数据 |
 |---|---|---|
-| `POST /api/node/dtuinfo` | `client.run()` 完成后 | DTU 设备参数 |
-| `POST /api/node/UartData` | `fetch.queryData(result)` | 查询结果集 |
-| `POST /api/node/RunData` | (未在 src 中使用) | 节点运行数据 |
-| `POST /api/node/nodeInfo` | `IOClient.on('nodeInfo')` | Node 机器信息 + tcp 连接数 |
-| `POST /api/node/queryData` | `fetch.queryData(SuccessResult)` | 单条查询结果 |
+| `POST /api/node/dtuinfo` | `dtus/cellular.ts:CellularDtu.initialize()` 完成后 | DTU 设备参数 |
+| `POST /api/node/queryData` | `dtus/base.ts:Dtu.queryInstruct` 成功后 | 单条查询结果 |
+| `POST /api/node/nodeInfo` | `main.ts:on('nodeInfo')` | Node 机器信息 + tcp 连接数 |
+| `POST /api/node/UartData` | (未在 src 中使用) | 节点运行数据 |
+| `POST /api/node/RunData` | (未在 src 中使用) | 节点运行数据（重复 UartData）|
 
-**`/api/node/*` 鉴权**：header `x-node-token: <NODE_TOKEN>`（`fetch.ts:46`），
+**`/api/node/*` 鉴权**：header `x-node-token: <NODE_TOKEN>`（`services/uploader.ts:runItem`），
 对应 server 端 PR #20 鉴权。
 
-## 5. 下行指令优先级（`client.saveCache` 排队列）
+**实现链路**：
+- `src/fetch.ts` 是 API surface（3 个方法 default export 单例）
+- `src/services/uploader.ts` 是队列 + 背压 + 重试实现（PR #2）
+- `src/fetch.ts` 内部 `import * as uploader from './services/uploader'`，3 个方法走 `uploader.enqueue('path', body)`
+
+## 5. 下行指令优先级（`dtus/base.ts:Dtu.saveCache` 排队列）
 
 ```ts
-switch (Query.eventType) {
-  case "QueryInstruct":  this.Cache.push(Query)              // 普通查询，FIFO
-  case "ATInstruct":     this.Cache.unshift(Query)           // AT 指令，插队最前
-  case "OprateInstruct": this.Cache.unshift(Query)           // 操作指令，插队最前
+// dtus/base.ts:Dtu.saveCache (基类通用, 跟 v3.3.0 1:1 兼容)
+switch (query.eventType) {
+  case 'QueryInstruct':  this.cache.push(query)              // 普通查询，FIFO
+  case 'ATInstruct':     this.cache.unshift(query)           // AT 指令，插队最前
+  case 'OprateInstruct': this.cache.unshift(query)           // 操作指令，插队最前
 }
 ```
 
@@ -103,9 +126,91 @@ switch (Query.eventType) {
 
 ## 6. 死循环 / 异常路径
 
-- **设备查询堆积 > 3** → `busy` 事件给 server（`client.ts:312`），业务侧可告警
-- **某个 pid 全部超时 10 次** → 触发 `AT+Z` 硬重启（`client.ts:387-390`）
-- **IOClient 断开** → 仅打印日志，**不自动 close TcpServer**（`main.ts:26-29` 注释里说"tcpServer.close()" 已注释掉）
+- **设备查询堆积 > 3** → `busy` 事件给 server（`dtus/base.ts:Dtu.processingQueue`），业务侧可告警
+- **某个 pid 全部超时 10 次** → 触发 `CellularDtu.restart()`（基类约定）走 `AT+Z` 硬重启
+  （`dtus/base.ts:Dtu.queryInstruct` + `dtus/cellular.ts:CellularDtu.restart`）
+- **IOClient 断开** → 仅打印日志，**不自动 close TcpServer**（`main.ts` 的 disconnect handler
+  注释里说 "tcpServer.close()" 已注释掉）
   - 风险：server 短暂断连，DTU 这边连接全保留，重连后可能状态不一致
 - **DTU socket timeout** → 5 分钟无活动（`config.timeOut`）→ `setTimeout` 触发但**没 destroy**
-  - `socket.ts:40-42` 仅打 log，没主动断开。**这是 bug**
+  - `src/socket.ts:40-42` 仅打 log，没主动断开。**这是 bug**
+- **Dtu state 非法转换** → PR #12 升级到 `console.error` + emit `dtuAlert` `INVALID_STATE_TRANSITION`
+  （不再静默忽略，8 天 staging 回归暴露 dtuStateLatest=0 根因之一已修）
+- **Uploader 失败** → 指数退避重试 2 次（`services/uploader.ts:runItem`），最终放弃 console.error
+
+## 7. 鉴权链路（PR #20）
+
+### 7.1 Socket.IO 握手（Node → Server 连接时）
+
+Node 端把 `NODE_TOKEN` 同时放在 3 个握手通道（`src/IO.ts:21-29` + `src/services/io-client.ts:43-50`）：
+
+1. `auth.token` — 推荐通道，websocket / polling 都吃
+2. `query.token` — 备选通道
+3. `x-node-token` header（`extraHeaders` + `transportOptions` 双保险）— 4.5+ websocket 阶段
+   extraHeaders 失效已修（4.7.5 默认带 transportOptions）
+
+### 7.2 HTTP `/api/node/*`（Node → Server 上行时）
+
+`src/services/uploader.ts:runItem` 在每次 fetch POST 时把 `NODE_TOKEN` 塞在 `x-node-token` header。
+
+### 7.3 双版本并存
+
+PR #1 落地了 `src/services/io-client.ts`（class 版本），但 `main.ts` 还在用 `src/IO.ts`（顶层单例），
+两个版本都设置 PR #20 三通道。`src/services/io-client.ts` 给 `dtus/base.ts` + `services/*` 内部用。
+下次动 `main.ts` 时切到 `getIOClient()`，然后删 `src/IO.ts`。
+
+## 8. DTU ↔ Node 数据流（设备层协议，4G 当前路径）
+
+### 8.1 DTU → Node 上行（`server/tcp-server.ts:onConnection`）
+
+```
+socket.on('data', firstPacket)             // DTU 发的注册包
+  ├── CellularSniffer.match(firstPacket)   // 嗅探 'register&' 前缀
+  ├── CellularRegisterHandler.handle(socket, firstPacket, macSocketMaps, conf)
+  │     ├── URLSearchParams(firstPacket).has('register') + has('mac')
+  │     ├── IMEI.slice(-12)  ←  mac 主键
+  │     ├── 已有 mac → existing.reConnectSocket(socket)
+  │     └── 新 mac → new CellularDtu(socket, mac, getIOClient())
+  │           ├── new socketsb(socket, mac)
+  │           ├── getIOClient().terminalOn(mac, false)
+  │           ├── Dtu.constructor  → bindSocket
+  │           └── Dtu.bindSocket    → initialize()  // 8 条 AT 批量查
+  └── (后续 socket.data 直接走 socketsb.write() 反向响应)
+```
+
+### 8.2 Node → DTU 下行（`dtus/base.ts:Dtu.saveCache` + `processingQueue`）
+
+```
+Dtu.saveCache(query)  // 由 tcpServer.bus() 调用
+  ├── switch eventType
+  │     ├── QueryInstruct:  cache.push(query)
+  │     ├── ATInstruct:     cache.unshift(query)
+  │     └── OprateInstruct: cache.unshift(query)
+  └── socketsb.getSocket().emit('Queue')
+        → Dtu.processingQueue()
+              ├── case QueryInstruct:  queryInstruct(query)  // 基类通用
+              └── case Oprate/AT:      processQueue(query)    // 子类实现
+```
+
+## 9. 与 v3.3.0 老代码的差异（RFC 002 落地带来的）
+
+| 维度 | v3.3.0 | v4 (当前) |
+|---|---|---|
+| TCP server | `TcpServer extends net.Server` | `TcpServer` class + `net.createServer()` 包裹（PR #5）|
+| 设备抽象 | `Client` 单一类（绑死 4G）| `Dtu` 抽象基类 + `CellularDtu` 实现（PR #4）|
+| 协议嗅探 | 硬编码 4G | `ProtocolSniffer[]` 数组化，未来 LAN push 一个（PR #5）|
+| Socket.IO client | 顶层单例副作用 | class + factory + `getIOClient()`（PR #1）|
+| HTTP 上行 | `fetch` 单点 + console.log | 队列 + 背压 + 重试（PR #2）|
+| AT 解析 | `tool.ATParse()` 静态方法 | `parseATResponse()` 纯函数 + Result 类型（PR #3）|
+| nodeInfo | `tool.NodeInfo()` 静态方法 | `nodeInfo()` 纯函数（PR #4 拆出）|
+| 状态机 | 无 | 8 态 + 转换表 + computeHealth + 5 类 alert（PR #6 + #12）|
+| 健康度上报 | 无 | 60s 周期 dtuHealth（ONLINE/DEGRADED 才发）|
+| Listen port | `NODE_ENV` 模式判断（DCE bug）| `resolveListenPort()` 全 env 驱动（PR #5 顺手修）|
+
+**不变量**（v3.3.0 → v4 行为契约 1:1）：
+- DTU 注册包解析（URLSearchParams + IMEI.slice(12) + 已有 mac 走 reConnectSocket）
+- 10s 推 `+++AT+` 仪式
+- 队列调度（QueryInstruct FIFO + AT/Oprate unshift）
+- 10 次超时硬重启
+- IOClient 三通道 token
+- HTTP `x-node-token` header 鉴权

--- a/.harness/docs/architecture/source-map.md
+++ b/.harness/docs/architecture/source-map.md
@@ -1,6 +1,9 @@
 # src/ 代码地图
 
-> **Source**: 实读 UartNode v3.3.0 分支 `fix/dce-config-env-driven`（commit 6fa4359）8 个源文件
+> **Source**: 实读 UartNode v3.3.0 + v4 重构（RFC 002）落地后 main 分支（commit `aee7eea`）
+> **Sync**: 2026-07-14 sync with PR #1-#12 落地（dev 机 13:44 session，cairui 拍板 "都修"）
+> **重构前快照**：本文件 v1 写的是 PR #1 之前 8 个 src/ 文件 + 老 `TcpServer.ts` extends `net.Server` 路径。
+> v4 落地后 src/ 拆成 14 个文件 + 4 个子目录，老 source-map.md 内容已 stale。
 
 ## 0. 一图流
 
@@ -10,39 +13,54 @@
 │  ↑ Socket.IO 事件              ↑ HTTP POST /api/node/*           │
 │  │                              │                                │
 └──┼──────────────────────────────┼────────────────────────────────┘
-   │ IO.ts (client)               │ fetch.ts (http)
+   │ IO.ts / services/io-client  │ fetch.ts → services/uploader
    ↓                              ↓
 ┌──────────────────────────────────────────────────────────────────┐
 │  main.ts — 事件路由                                              │
 │  • IOClient.on('registerSuccess') → 启动 TcpServer                │
-│  • IOClient.on('query')         → tcpServer.Bus('QueryInstruct')  │
-│  • IOClient.on('instructQuery') → tcpServer.Bus('OprateInstruct')│
-│  • IOClient.on('DTUoprate')     → tcpServer.Bus('ATInstruct')    │
+│  • IOClient.on('query')         → tcpServer.bus('QueryInstruct')  │
+│  • IOClient.on('instructQuery') → tcpServer.bus('OprateInstruct')│
+│  • IOClient.on('DTUoprate')     → tcpServer.bus('ATInstruct')    │
 │  • IOClient.on('nodeInfo')      → fetch.nodeInfo(...)             │
 └──┬───────────────────────────────────────────────────────────────┘
    │
    ↓
 ┌──────────────────────────────────────────────────────────────────┐
-│  TcpServer.ts — net.Server :9000                                 │
-│  • 10s 推 AT 仪式 (4G 专属)                                      │
-│  • URLSearchParams 解析注册包 (4G 专属)                           │
-│  • MacSocketMaps: Map<mac, Client>  ← 设备身份                    │
-│  • Bus() 派发下行指令                                            │
+│  server/tcp-server.ts — TCP Server :9000 (PR #5 class 化)        │
+│  • sniffers: ProtocolSniffer[]     ← 数组化，未来 LanDtu push 一个│
+│  • registerHandlers: RegisterHandler[]  ← 跟 sniffers 一一对应     │
+│  • macSocketMaps: Map<mac, Dtu>    ← 设备身份 (老 MacSocketMaps)  │
+│  • bus() 派发下行指令（query / AT / operate）                     │
+│  • resolveListenPort() 全 env 驱动（PR #5 顺手清掉 NODE_ENV DCE） │
 └──┬───────────────────────────────────────────────────────────────┘
    │
-   ↓ 1 个 DTU 1 个 Client
+   ↓ 1 个 DTU 1 个 Dtu
 ┌──────────────────────────────────────────────────────────────────┐
-│  client.ts — 单 DTU 运行时抽象                                   │
-│  • 状态: mac/jw/uart/AT/ICCID/PID/ver/Gver/iotStat/signal        │
-│  • run() 批量查 AT 指令 (4G 专属)                                 │
-│  • QueryAT() 拼 '+++AT+' 前缀 (4G 专属)                          │
-│  • Cache 队列: QueryInstruct/OprateInstruct/ATInstruct            │
-│  • 超时 10 次硬重启策略 (AT+Z)                                   │
+│  dtus/base.ts — Dtu 抽象基类 (PR #4 + #6)                        │
+│  • 8 态状态机: CONNECTING / HANDSHAKING / INITIALIZING /          │
+│    ONLINE / DEGRADED / RECONNECTING / RESTARTING / OFFLINE       │
+│  • 健康度 0-100 + computeHealth() 纯函数                          │
+│  • 5 类 alert: AT_TIMEOUT / INVALID_REGISTER /                  │
+│    PROFILE_CACHE_FAIL / FATAL / INVALID_STATE_TRANSITION (PR #12)│
+│  • 60s 周期 dtuHealth 上报（ONLINE/DEGRADED 才发）                │
+│  • FIFO 队列 + AT/Oprate 插队到队首 + socket 锁 + 10 次硬重启    │
+│  • 抽象: initialize() / restart() / processQueue()               │
+└──┬───────────────────────────────────────────────────────────────┘
+   │
+   ↓ extends
+┌──────────────────────────────────────────────────────────────────┐
+│  dtus/cellular.ts — 4G/2G/NB 实现 (PR #4)                        │
+│  • initialize() 批量查 8 条 AT (4G 专属)                          │
+│    PID / VER / GVER / IOTEN / ICCID / LOCATE=1 / UART=1 / GSLQ    │
+│    + IOTEN=off 关流量                                            │
+│  • restart() 走 AT+Z（4G 专属）                                  │
+│  • processQueue() 处理 OprateInstruct / ATInstruct                │
+│  • queryAT() 拼 '+++AT+<content>\r'（4G 专属前缀）                │
 └──┬───────────────────────────────────────────────────────────────┘
    │
    ↓
 ┌──────────────────────────────────────────────────────────────────┐
-│  socket.ts — 纯 TCP socket 封装 (与协议无关)                     │
+│  socket.ts — 纯 TCP socket 抽象 (与协议无关)                     │
 │  • setTimeout(5min) / setKeepAlive(100s) / setNoDelay(true)      │
 │  • write() 返回 Promise<socketResult>, lock/free 事件机制        │
 │  • ProxySocket 拦截状态变更 emit 业务事件                         │
@@ -52,124 +70,149 @@
    ╳ DTU 端
 ```
 
-## 1. 文件职责速查
+## 1. 文件职责速查（v4 重构后，2026-07-14 sync）
 
 | 文件 | 行数 | 职责 | 协议相关 | 改 LAN 时动它？ |
 |---|---|---|---|---|
-| `main.ts` | 72 | 事件路由：IO ↔ TcpServer | **否** | 不动 |
-| `config.ts` | 92 | 全 env 配置 + 事件名常量 | **否** | 加 LAN topology enum |
-| `IO.ts` | 69 | Socket.IO 客户端 + PR #20 鉴权 | **否** | 不动 |
-| `fetch.ts` | 66 | HTTP 上行 + PR #20 鉴权 | **否** | 不动 |
-| `TcpServer.ts` | 152 | TCP Server，10s 推 AT + 注册包解析 | **是，4G 专属** | **重构** |
-| `client.ts` | 475 | 单 DTU 抽象，AT 指令 + 缓存队列 | **是，4G 绑死** | **拆 + 新增 LAN 类** |
-| `socket.ts` | 150 | 纯 socket 抽象 | **否** | 不动（Client 模式可复用） |
-| `tool.ts` | 45 | AT 响应解析 + 节点信息 | **是，4G 专属** | 加 LanCliParse |
-| `Cache.ts` | 55 | （已废弃）直传 fetch | **否** | 不动 |
+| `main.ts` | ~70 | 事件路由：IO ↔ TcpServer | **否** | 不动 |
+| `config.ts` | ~95 | 全 env 配置 + 事件名常量 | **否** | 加 LAN topology enum |
+| `IO.ts` | ~70 | Socket.IO 客户端（顶层单例）+ PR #20 鉴权 | **否** | 不动（待 PR #1 class 化版本完全替换） |
+| `services/io-client.ts` | ~230 | Socket.IO client class 化（PR #1）| **否** | 不动 |
+| `fetch.ts` | ~70 | HTTP 上行 API surface（dtuInfo/nodeInfo/queryData）| **否** | 不动 |
+| `services/uploader.ts` | ~170 | HTTP 上行队列+背压+重试实现（PR #2）| **否** | 不动 |
+| `services/at-parse.ts` | ~90 | AT 响应解析纯函数（PR #3）| **是，4G 专属** | 加 LanParse |
+| `services/dtu-info.ts` | ~35 | nodeInfo 纯函数 | **否** | 不动 |
+| `server/tcp-server.ts` | ~190 | TCP Server，class 化 + sniffers 数组化（PR #5）| **是，4G 专属** | **重构**（sniffers 已数组化）|
+| `server/register-handler.ts` | ~110 | 协议嗅探 + 注册包解析 | **是，4G 专属** | **重构** |
+| `dtus/base.ts` | ~470 | Dtu 抽象基类（状态机+健康度+alert+队列）| **否** | 通用基类，不动 |
+| `dtus/cellular.ts` | ~155 | 4G/2G/NB DTU 实现 | **是，4G 绑死** | **拆 + 新增 LanDtu 类** |
+| `dtus/state.ts` | ~290 | 状态机纯函数层（8 态 + computeHealth + 5 类 alert）| **否** | 通用，不动 |
+| `protocol/events.ts` | ~200 | Socket.IO 事件名常量 + payload 类型 | **部分**（3 个 v4 新事件）| 不动（LAN 复用）|
+| `Cache.ts` | ~55 | **死代码**（没人 import）| **否** | 不动 / 真清就删 |
+| `tool.ts` | ~10 | **空占位**（PR #3/#4 拆完后留的 import 占位）| — | 不动 |
 
-**关键结论**：LAN 改造**只动** `TcpServer.ts` / `client.ts` / `tool.ts` 三个文件 + 新增 1-2 个 adapter 文件。
+**关键结论**：LAN 改造**只动** `dtus/cellular.ts` / `services/at-parse.ts` / `server/register-handler.ts` 三个文件 + 新增 1-2 个 adapter（`dtus/lan.ts` / `services/lan-parse.ts`）+ `server/tcp-server.ts` 的 sniffers push 一个新 sniffer（不用动嗅探/注册处理逻辑）。
 
-**已知 bug 残留**（commit 6fa4359 修了 `config.ts`，**没修** `TcpServer.ts`）：
+**已修的 bug**（PR #5 重构顺手清掉）：
 
-- `TcpServer.ts:37, 49` 还在用 `process.env.NODE_ENV === 'production' ? conf.Port : config.localport`
-- bun build --minify 后 DCE 掉 prod 分支，**容器跑 prod host 永远走 `config.localport = 9000`**
-- 如果将来 `conf.Port` 不是 9000（server 端下发非默认 port），`NODE_ENV=production` 的容器会**连错端口**
-- 改 TcpServer 时**顺手清掉这俩**，改成全 env：`process.env.LISTEN_PORT ?? conf.Port ?? config.localport`
+- ~~`TcpServer.ts:37, 49` 还有 2 处 `process.env.NODE_ENV === 'production' ? conf.Port : config.localport`~~
+  → 改用 `src/server/tcp-server.ts:resolveListenPort()` 全 env 驱动
+  （`LISTEN_PORT` env → `conf.Port` → `config.localport = 9000`）。不再有 DCE bug。
 
-## 2. 关键调用链
+## 2. 关键调用链（v4 重构后）
 
 ### 2.1 DTU 上线（4G 当前路径）
 
 ```
-TcpServer._Connection(socket)
-  ├── setTimeout(10s, 推 AT 仪式)
-  ├── socket.once('data', parseRegister)
-  │     ├── 命中: new Client(socket, mac, registerArgs)
-  │     │     ├── new socketsb(socket, mac)  // socket.ts
-  │     │     ├── IOClient.emit('terminalOn', mac, false)
-  │     │     └── socketOn → run()  // 批量查 AT
-  │     │           └── QueryAT(...) × 8 次
-  │     └── 不命中: socket.end('please register DTU IMEI')
-  └── (MacSocketMaps.set(mac, Proxy(client, ProxyClient)))
+server/tcp-server.ts:onConnection(socket)
+  ├── setTimeout(10s, pushCellularRegisterInvite)
+  │     └── socket.write('+++AT+NREGEN=A,on\r') × 3
+  ├── socket.once('data', firstPacket)
+  │     ├── sniffers.find(s => s.match(firstPacket))
+  │     │     ├── CellularSniffer.match() → startsWith('register&')
+  │     │     └── handler.handle(socket, firstPacket, macSocketMaps, conf)
+  │     │           ├── URLSearchParams(firstPacket).has('register') + has('mac')
+  │     │           ├── IMEI.slice(-12)  ←  mac 主键（v4 改 15 位前保持）
+  │     │           ├── 已有 mac → existing.reConnectSocket(socket)
+  │     │           └── 新 mac → new CellularDtu(socket, mac, getIOClient())
+  │     │                 ├── new socketsb(socket, mac)  // socket.ts
+  │     │                 ├── getIOClient().terminalOn(mac, false)
+  │     │                 └── bindSocket → initialize()  // 8 条 AT 批量查
+  │     │                       └── queryAT(...) × 8
+  │     └── 不命中: socket.end('please register DTU IMEI') + destroy
+  └── macSocketMaps.set(mac, dtu)
 ```
 
 ### 2.2 Server 下发查询（来自 uart-server 的指令）
 
 ```
-IOClient.on('query', Query)
-  └── tcpServer.Bus('QueryInstruct', Query)
-        └── client.saveCache(Query)  // 塞队列
-              └── ProcessingQueue()
-                    └── QueryInstruct(Query)
-                          ├── for (content of Query.content)
+IOClient.on('query', Query)            // main.ts
+  └── tcpServer.bus('QueryInstruct', Query)
+        └── dtus/base.ts:Dtu.saveCache(Query)  // 塞 cache 队列
+              └── processingQueue()  // 基类通用调度
+                    └── queryInstruct(query)  // 基类通用实现
+                          ├── for (content of query.content)
                           │     └── socketsb.write(queryString, 10000, --len !== 0)
-                          └── fetch.queryData(result)  // 上行
+                          ├── 全部超时 → terminalMountDevTimeOut + 10 次硬重启
+                          ├── 部分超时 → instructTimeOut + 上报成功部分
+                          └── fetch.queryData(successResult)  // 上行
 ```
 
 ### 2.3 Server 下发 AT 指令
 
 ```
-IOClient.on('DTUoprate', Query)
-  └── tcpServer.Bus('ATInstruct', Query)
-        └── client.saveCache(Query)  // ATInstruct 走 unshift 优先
-              └── ProcessingQueue()
+IOClient.on('DTUoprate', Query)        // main.ts
+  └── tcpServer.bus('ATInstruct', Query)
+        └── Dtu.saveCache(Query)  // ATInstruct 走 unshift 优先
+              └── processingQueue()
                     └── case 'ATInstruct':
+                          ├── cellular.ts:processQueue
                           ├── Buffer.from(query.content + '\r', 'utf-8')
                           ├── socketsb.write(queryString)
-                          └── ATParse(query, result)
-                                └── tool.ATParse(buffer)  // 匹配 ^\+ok
+                          └── atParse(query, result)  // base.ts atParse → parseATResponse
+                                └── /^\+ok=/ 匹配 (services/at-parse.ts)
 ```
 
 ### 2.4 DTU 查询超时硬重启
 
 ```
-QueryInstruct → all timeout (10 次)
-  └── resatrtSocket()
-        └── QueryAT('Z')  // 硬重启 AT 指令
-              └── this.reboot = true
-                    └── socket.destroy()
-                          └── 60s 内重连走 reConnectSocket()
+QueryInstruct → all timeout (10 次)  // dtus/base.ts:queryInstruct
+  └── Dtu.restart()  // cellular.ts:restart
+        ├── setPause 等 socket 空闲
+        ├── queryAT('Z')  // 拼 '+++AT+Z\r'
+        ├── this.reboot = true
+        └── socketsb.getSocket().destroy()  // 触发 terminalOff + 60s 后重发 terminalOn(reline=true)
+              └── 60s 内重连走 reConnectSocket(socket)
+                    └── bindSocket → initialize()  // 重跑 8 条 AT
 ```
 
 ## 3. 关键状态/常量
 
-| 名称 | 文件:行 | 含义 |
+| 名称 | 文件:行（v4） | 含义 |
 |---|---|---|
-| `MacSocketMaps` | `TcpServer.ts:16` | `Map<mac, Client>` 设备身份表 |
-| `config.timeOut` | `config.ts:83` | 5 分钟 socket 超时 |
-| `config.queryTimeOut` | `config.ts:85` | 1.5s 单条查询超时 |
-| `config.queryTimeOutNum` | `config.ts:87` | 10 次超时触发硬重启 |
-| `config.queryTimeOutReload` | `config.ts:89` | 60s 重启时间（未使用）|
-| `config.count` | `config.ts:91` | 在线设备数（运行时累加）|
-| `config.localport` | `config.ts:81` | 9000 TCP 监听端口 |
-| `TcpServer.MaxConnections` | `TcpServer.ts:24` | 2000（注意：setMaxListeners 是 2000，但 net.Server 实际并发可达系统限制）|
-| `_Connection.timeOut` | `TcpServer.ts:71` | **10s** —— 推 AT 仪式的等待时间 |
+| `macSocketMaps` | `server/tcp-server.ts:TcpServer.macSocketMaps` | `Map<mac, Dtu>` 设备身份表 |
+| `config.timeOut` | `config.ts` | 5 分钟 socket 超时（socket.ts:40-42 没主动 destroy）|
+| `config.queryTimeOut` | `config.ts` | 1.5s 单条查询超时 |
+| `config.queryTimeOutNum` | `config.ts` | 10 次超时触发硬重启 |
+| `config.queryTimeOutReload` | `config.ts` | 60s 重启时间（未使用）|
+| `config.count` | `config.ts` | 在线设备数（运行时累加）|
+| `config.localport` | `config.ts` | 9000 TCP 监听端口（dev fallback）|
+| `conf.Port` | server registerSuccess 下发 | TCP 监听端口（prod 优先）|
+| `process.env.LISTEN_PORT` | env | 部署期灵活覆盖（PR #5 新增）|
+| `REGISTER_INVITE_DELAY_MS` | `server/tcp-server.ts` | 10s 推 AT 仪式的等待时间 |
+| `MaxConnections` | `server/tcp-server.ts` | 2000（setMaxListeners + 并发上限）|
+| `UPLOAD_TIMEOUT_MS` | `services/uploader.ts` | 30s（2026-06-22 hotfix 5s → 30s）|
+| `UPLOAD_CONCURRENCY` | `services/uploader.ts` | 4（UartNode 单进程流量小，pesiv 是 16）|
+| `UPLOAD_QUEUE_MAX` | `services/uploader.ts` | 1000（满队 drop oldest）|
+| `HEALTH_REPORT_INTERVAL_MS` | `dtus/state.ts` | 60s 周期 dtuHealth 上报（ONLINE/DEGRADED 才发）|
+| `MAX_RECONNECT_ATTEMPTS` | `dtus/state.ts` | 5 次重连 |
 
 ## 4. 跟协议相关的硬编码点（**改 LAN 时要碰**）
 
-| 点 | 文件:行 | 硬编码什么 | LAN 怎么办 |
+| 点 | 文件:行（v4）| 硬编码什么 | LAN 怎么办 |
 |---|---|---|---|
-| 10s 推 AT | `TcpServer.ts:71-81` | `+++AT+NREGEN/A,on\r` 等汉枫 4G 指令 | 拓扑 A/B 不推 |
-| 注册包解析 | `TcpServer.ts:92-115` | `URLSearchParams` + 判 `register+mac` | 改成白名单查 mac |
-| IMEI 后 12 位当 mac | `TcpServer.ts:96-100` | `IMEI.slice(maclen-12, maclen)` | LAN 用 MAC 12 字符 |
-| `+++AT+` 前缀 | `client.ts:196` | `'+++AT+${content}\r'` | LAN 改 CLI / HTTP API |
-| 批量查 4G 字段 | `client.ts:126-146` | PID/VER/GVER/ICCID/LOCATE/UART/GSLQ/IOTEN | LAN 大半无意义 |
-| `+ok` 解析 | `tool.ts:35` | `/(^\+ok)/.test(str)` | LAN 改 EPORT> 提示符或 HTTP |
-| `AT+Z` 硬重启 | `client.ts:273` | `'Z'` | LAN 走 Web/REST API |
-| 10s timeout 写死 | `TcpServer.ts:71` | `setTimeout(..., 10000)` | LAN 拓扑要可配 |
-| **残留 `NODE_ENV` 模式判断** | `TcpServer.ts:37, 49` | `process.env.NODE_ENV === 'production' ? conf.Port : config.localport` | bun build --minify 会 DCE 掉，**prod 容器跑不到 prod 端口**——必须**全 env 改写**（commit 6fa4359 修了 config.ts，没修 TcpServer）|
+| 10s 推 AT | `server/tcp-server.ts:onConnection` + `server/register-handler.ts:pushCellularRegisterInvite` | `+++AT+NREGEN/A,on\r` 等汉枫 4G 指令 | 拓扑 A/B 不推 |
+| 注册包解析 | `server/register-handler.ts:CellularRegisterHandler.handle` | `URLSearchParams` + 判 `register+mac` | 改成白名单查 mac |
+| IMEI 后 12 位当 mac | `server/register-handler.ts:CellularRegisterHandler.handle` | `IMEI.slice(maclen-12, maclen)` | LAN 用 MAC 12 字符 |
+| `+++AT+` 前缀 | `dtus/cellular.ts:queryAT` | `'+++AT+${content}\r'` | LAN 改 CLI / HTTP API |
+| 批量查 4G 字段 | `dtus/cellular.ts:initialize` | PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ | LAN 大半无意义 |
+| `+ok=` 解析 | `services/at-parse.ts:parseATResponse` | `/^\+ok=/i.test(str)` | LAN 改 `EPORT>` 提示符或 HTTP |
+| `AT+Z` 硬重启 | `dtus/cellular.ts:restart` | `queryAT('Z')` | LAN 走 Web/REST API |
+| 10s timeout 写死 | `server/tcp-server.ts:REGISTER_INVITE_DELAY_MS` | `10_000` ms | LAN 拓扑要可配 |
+| 8 条 AT 批量查顺序 | `dtus/cellular.ts:initialize` | 固定 PID → VER → GVER → IOTEN → ICCID → LOCATE → UART → GSLQ | LAN 大半无意义 |
 
 ## 5. 跟协议**无关**的可复用层
 
 | 层 | 文件 | 为什么无关 |
 |---|---|---|
-| Socket.IO 客户端 | `IO.ts` | 只跟 server 通信，不碰 DTU |
-| HTTP fetch | `fetch.ts` | 同上 |
-| Cache | `Cache.ts` | 已废弃成直通 |
-| 事件名常量 | `config.ts` EVENT_* | 业务事件命名，4G/LAN 通用 |
+| Socket.IO 客户端 | `IO.ts` + `services/io-client.ts` | 只跟 server 通信，不碰 DTU |
+| HTTP fetch | `fetch.ts` + `services/uploader.ts` | 同上 |
+| Dtu 基类 | `dtus/base.ts` | 状态机/健康度/alert/队列/超时重启都通用 |
+| 状态机纯函数 | `dtus/state.ts` | 8 态 + computeHealth + 5 类 alert 通用 |
+| 事件名常量 | `protocol/events.ts` | 13 老事件 + 3 新事件，4G/LAN 通用 |
 | Config env | `config.ts` | 全 env 驱动，IO_URI/SERVER_URL/NODE_TOKEN |
-| nodeInfo | `tool.ts` NodeInfo | 节点机器信息，与协议无关 |
+| nodeInfo | `services/dtu-info.ts` | 节点机器信息，与协议无关 |
 | socket 抽象 | `socket.ts` | 纯 TCP 封装，setKeepAlive/setNoDelay 等可复用 |
 | main.ts 路由 | `main.ts` | 单纯事件分发 |
-| ProxyClient | `client.ts:471-475` | no-op 透传 Proxy，与协议无关 |
 
-**这意味着**：LAN 改造时这些文件**完全不动**。改动集中在 4G 专属层。
+**这意味着**：LAN 改造时这些文件**完全不动**。改动集中在 4G 专属层 + 新增 LanDtu 类 + sniffers push。

--- a/.harness/docs/changelogs/2026-07-14-docs-sync-v4.md
+++ b/.harness/docs/changelogs/2026-07-14-docs-sync-v4.md
@@ -1,0 +1,97 @@
+# 2026-07-14 docs sync with v4 refactor (PR #1-#12)
+
+## 触发
+
+- cairui session `mvs_ee8e2927968b4aa6b51e7b5fc03442b8` 14:00 起来看 uart-node 架构
+- 发现 4 个文档 stale（写的是 PR #1 之前老代码 + 老 `TcpServer.ts` extends `net.Server` 路径）
+- cairui 拍板 "都修"
+
+## 改了哪些
+
+### `AGENTS.md`
+
+| 段 | 改动 |
+|---|---|
+| 鉴权 | 加 `src/IO.ts` 顶层单例 vs `src/services/io-client.ts` class 化并存说明，TODO 写"下次动 main.ts 时切到 getIOClient() 然后删 src/IO.ts" |
+| 未回归的运行时风险 | 文件路径从老 `TcpServer.ts` 改成 `src/server/tcp-server.ts` + `src/server/register-handler.ts` + `src/dtus/cellular.ts` |
+| | ~~"TcpServer.ts:37, 49 残留 NODE_ENV"~~ → 标 "PR #5 重构时已修"，引用 `resolveListenPort()` 全 env 驱动 |
+| 当前协议支持范围 | 8 条 AT 批量查 (`PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ` + `IOTEN=off`) + "6 处硬编码" 跟 README 对齐 |
+| | 加 `services/at-parse.ts` 匹配 `+ok=...` 响应 + 8 态状态机 + 5 类 alert |
+| 已废弃代码 | 加 `src/tool.ts` 空占位段（新代码不要 import，要 AT 解析用 `services/at-parse`、要 nodeInfo 用 `services/dtu-info`）|
+| 测试 | **从"没有测试"改成"201 tests / 198 pass / 3 fail / 10 files"** + 3 fail 根因分析（test 顺序依赖 / mock.restore + retry 跨 test 边界）|
+| GitHub | Repo `wgcairui/UartNode` 大写 → `wgcairui/uart-node` 小写 + 加 gh CLI 不读 GH_TOKEN env 踩坑提醒 |
+| 仓库知识库 | 仓库知识库引用路径从 `src/TcpServer.ts` 改成 `src/server/tcp-server.ts` 等 |
+
+### `README.md`
+
+| 段 | 改动 |
+|---|---|
+| 架构图 | 顶层 8 个文件 → 14 个文件 + 4 个子目录（`server/` / `dtus/` / `services/` / `protocol/`）|
+| 4G 硬编码点表 | 行号从老 `client.ts:196` / `TcpServer.ts:71-81` / `tool.ts:35` 等改成 v4 新路径 |
+| 已知 bug 残留 | ~~`TcpServer.ts:37, 49` NODE_ENV DCE~~ → 标 "PR #5 重构时清掉"，不再有 DCE bug |
+| 测试 | 加 `## 测试` 段：`bun test` 命令 + 10 spec 文件清单 + 3 fail 警示 |
+
+### `.harness/docs/architecture/source-map.md`
+
+- 整文件重写
+- 14 个 src/ 文件职责速查表（含行数 + 协议相关性 + 改 LAN 时动它）
+- 一图流更新到 v4 路径
+- 关键调用链 2.1-2.4 改成 v4 新文件
+- 关键状态/常量表改成 v4 新行号
+- 4G 硬编码点表改成 v4 新位置
+- 跟协议无关可复用层表加 5G/LAN 友好的层（`dtus/base.ts` / `dtus/state.ts` / `protocol/events.ts` / `services/io-client.ts`）
+- 加 "v4 sync 2026-07-14" header
+
+### `.harness/docs/architecture/data-flow.md`
+
+- 整文件重写
+- 端到端时序图更新 v4 路径
+- §3 Node 主动事件加 v4 新 3 事件（`dtuState` / `dtuHealth` / `dtuAlert`）+ 5 类 alert
+- §4 上行 HTTP 路径表 + 实现链路说明（`src/fetch.ts` API surface + `src/services/uploader.ts` 队列实现）
+- §5 下行指令优先级代码块 `this.Cache.push` → `this.cache.push`（小写，v4 base.ts）
+- §6 死循环/异常路径加 "Dtu state 非法转换 → PR #12 console.error + emit alert" + "Uploader 失败 → 指数退避重试 2 次"
+- 加 §7 鉴权链路（Socket.IO 握手 + HTTP）+ §8 DTU ↔ Node 数据流（设备层协议）+ §9 v3.3.0 vs v4 差异表
+- 加 "v4 sync 2026-07-14" header
+
+## 没改的（待办）
+
+- **`3 fail` test 隔离 bug** —— `Uploader — 背压` 段 retry backoff 跨 test 边界残留，独立 PR 修：
+  - 选项 A：`afterEach` 加 `await waitDrain(retry_backoff_window)`
+  - 选项 B：给 retry 加测试钩子禁用
+  - 选项 C：拆 `Uploader — 背压` 进独立 spec 文件
+  - 选项 D：所有 test 跑前 reset queue / 全局 mock 不依赖 module-level state
+  - 选哪个 cairui 拍板
+- **PR #1 vs PR #5 双版本并存** —— `src/IO.ts` 顶层单例跟 `src/services/io-client.ts` class 并存
+  - 修法：下次动 `main.ts` 时切到 `getIOClient()`，然后删 `src/IO.ts`
+  - 已经写进 AGENTS.md TODO
+- **LAN 接入** —— RFC 001 还在 draft，6 处 4G 硬编码等 cairui 拍板
+- **PRD 状态机 PR #12 hotfix 升级** —— `dtuState` 事件 `INVALID_STATE_TRANSITION` alert
+  server 端需要 PR A 落库可见（`log.terminalEvents`）
+
+## 测试现状（2026-07-14 14:00 实测）
+
+```
+201 tests / 198 pass / 3 fail / 10 files / 15s
+```
+
+3 fail 集中在 `Uploader 便捷方法` 段（来自 `src/fetch.ts` 包装层），
+单独跑 `bun test test/services/uploader.test.ts` 全 pass（15 / 0），
+跑 `bun test test/services/uploader.test.ts test/server/tcp-server.test.ts` 也全 pass（27 / 0）。
+**不是产品 bug，是 test 隔离问题**。
+
+## 提交
+
+按主题拆 4 个 commit（每个文档一个 commit + 1 个 changelog commit）：
+
+```
+1. docs(AGENTS): sync with v4 refactor (PR #1-#12)
+2. docs(README): sync with v4 refactor + add test section
+3. docs(architecture): sync source-map + data-flow with v4 paths
+4. docs(changelogs): record 2026-07-14 docs sync
+```
+
+不拆更细（一个 commit 改 4 个文档）的原因是：
+- AGENTS.md 是 agent memory（项目级约定），改了要 commit message 突出
+- README.md 是用户面向的，commit message 突出"加测试段"
+- source-map.md + data-flow.md 都是 architecture/，归一类
+- changelogs/ 是元数据，归一类

--- a/.harness/scripts/commit-docs-sync-2026-07-14.sh
+++ b/.harness/scripts/commit-docs-sync-2026-07-14.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# 2026-07-14 docs sync with v4 refactor (PR #1-#12)
+# cairui session mvs_ee8e2927968b4aa6b51e7b5fc03442b8 起的，由于 session workspace
+# 快照锁的 /Users/cairui/Code/UartNode (大写) 在 commit 前被我 trash 掉了，
+# bash tool 全部 "Working directory does not exist" 失灵（user memory 2026-07-14 那条
+# 坑），写完文档 + changelog 后无法 commit。
+#
+# 用法：新 session 起来后，cd 到 /Users/cairui/Code/uart-node，跑：
+#   bash .harness/scripts/commit-docs-sync-2026-07-14.sh
+#
+# 拆 4 个 commit（每个 commit 一个主题，PR review 友好）：
+#   1. docs(AGENTS): sync with v4 refactor
+#   2. docs(README): sync with v4 refactor + add test section
+#   3. docs(architecture): sync source-map + data-flow with v4 paths
+#   4. docs(changelogs): record 2026-07-14 docs sync
+# 然后 push。
+
+set -euo pipefail
+
+REPO="/Users/cairui/Code/uart-node"
+cd "$REPO" || { echo "❌ cd failed: $REPO"; exit 1; }
+
+echo "📍 repo: $REPO"
+echo "🌿 branch: $(git branch --show-current)"
+echo "📊 status:"
+git status --short
+echo ""
+
+# 检查工作区干净（除了我们要 commit 的 5 个文件）
+EXPECTED_CHANGES=(
+  "M AGENTS.md"
+  "M README.md"
+  "M .harness/docs/architecture/source-map.md"
+  "M .harness/docs/architecture/data-flow.md"
+  "?? .harness/docs/changelogs/2026-07-14-docs-sync-v4.md"
+  "?? .harness/scripts/commit-docs-sync-2026-07-14.sh"
+)
+ACTUAL=$(git status --short | sort)
+EXPECTED_SORTED=$(printf '%s\n' "${EXPECTED_CHANGES[@]}" | sort)
+if [ "$ACTUAL" != "$EXPECTED_SORTED" ]; then
+  echo "⚠️  git status 跟预期不符，请人工检查："
+  echo "Expected:"
+  printf '  %s\n' "${EXPECTED_CHANGES[@]}"
+  echo "Actual:"
+  echo "$ACTUAL" | sed 's/^/  /'
+  echo ""
+  echo "如果只是多了/少了其他文件（比如 .harness/docs/changelogs/ 目录创建痕迹），"
+  echo "继续 commit 也安全，但确认前先 abort。"
+  read -rp "Continue? [y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]] || { echo "❌ aborted"; exit 1; }
+fi
+
+# ---- Commit 1: AGENTS.md ----
+echo "📝 [1/4] AGENTS.md"
+git add AGENTS.md
+git commit -m "docs(AGENTS): sync with v4 refactor (PR #1-#12)
+
+- 鉴权段加 src/IO.ts 顶层单例 vs src/services/io-client.ts class 化并存说明
+- 未回归的运行时风险段文件路径从老 TcpServer.ts 改成 src/server/tcp-server.ts +
+  src/server/register-handler.ts + src/dtus/cellular.ts
+- 标 TcpServer.ts:37,49 NODE_ENV DCE bug 已被 PR #5 重构时修复（resolveListenPort 全 env 驱动）
+- 当前协议支持范围段更新 8 条 AT 批量查顺序（PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ
+  + IOTEN=off 关流量）+ 加 8 态状态机 + 5 类 alert 引用
+- 已废弃代码段加 src/tool.ts 空占位说明
+- 测试段从'没有测试'改成'201 tests / 198 pass / 3 fail / 10 files' + 3 fail 根因分析
+- GitHub 段 repo 名 wgcairui/UartNode 大写 -> wgcairui/uart-node 小写 + gh CLI GH_TOKEN 踩坑提醒
+- 仓库知识库引用路径从 src/TcpServer.ts 改成 src/server/tcp-server.ts 等"
+
+# ---- Commit 2: README.md ----
+echo ""
+echo "📝 [2/4] README.md"
+git add README.md
+git commit -m "docs(README): sync with v4 refactor + add test section
+
+- 架构图段 src/ 顶层 8 个文件 -> 14 个文件 + 4 个子目录（server/ dtus/ services/ protocol/）
+- 4G 硬编码点表行号从老 client.ts:196 / TcpServer.ts:71-81 / tool.ts:35 等
+  改成 v4 新路径（server/tcp-server.ts / server/register-handler.ts / dtus/cellular.ts
+  / services/at-parse.ts 等）
+- 已知 bug 残留段标 TcpServer.ts:37,49 NODE_ENV DCE 已被 PR #5 重构时清掉
+- 加 '## 测试' 段：bun test 命令 + 10 spec 文件清单 + 3 fail 警示"
+
+# ---- Commit 3: architecture/source-map.md + data-flow.md ----
+echo ""
+echo "📝 [3/4] architecture/source-map.md + data-flow.md"
+git add .harness/docs/architecture/source-map.md
+git add .harness/docs/architecture/data-flow.md
+git commit -m "docs(architecture): sync source-map + data-flow with v4 paths
+
+- 整文件重写，跟 v4 重构（RFC 002 PR #1-#12）落地后文件路径同步
+- source-map.md 14 个 src/ 文件职责速查表（含行数 + 协议相关性 + 改 LAN 时动它）
+- source-map.md 一图流更新到 v4 路径，关键调用链 2.1-2.4 改成 v4 新文件
+- source-map.md 4G 硬编码点表改成 v4 新位置，5 段可复用层表加 dtus/base.ts / dtus/state.ts
+  / protocol/events.ts / services/io-client.ts
+- data-flow.md 端到端时序图更新 v4 路径
+- data-flow.md §3 Node 主动事件加 v4 新 3 事件（dtuState / dtuHealth / dtuAlert）+ 5 类 alert
+- data-flow.md §4 上行 HTTP 路径表 + 实现链路说明（src/fetch.ts API surface +
+  src/services/uploader.ts 队列实现）
+- data-flow.md §5 下行指令优先级代码块 this.Cache.push -> this.cache.push（小写，v4 base.ts）
+- data-flow.md §6 加 'Dtu state 非法转换 -> PR #12 console.error + emit alert' +
+  'Uploader 失败 -> 指数退避重试 2 次'
+- data-flow.md 加 §7 鉴权链路 + §8 DTU ↔ Node 数据流 + §9 v3.3.0 vs v4 差异表"
+
+# ---- Commit 4: changelogs + scripts ----
+echo ""
+echo "📝 [4/4] changelogs/ + scripts/"
+git add .harness/docs/changelogs/2026-07-14-docs-sync-v4.md
+git add .harness/scripts/commit-docs-sync-2026-07-14.sh
+git commit -m "docs(changelogs): record 2026-07-14 docs sync with v4 refactor
+
+- AGENTS.md / README.md / source-map.md / data-flow.md 各自改了啥
+- 已知 3 fail 状态（test 顺序依赖，独立 PR 待修）
+- PR #1 vs PR #5 双版本并存（src/IO.ts 顶层单例 vs src/services/io-client.ts class）
+- LAN 接入 RFC 001 还在 draft，等 cairui 拍板
+- commit 拆 4 个主题的决策记录
+- 加 .harness/scripts/commit-docs-sync-2026-07-14.sh 解决 session workspace 快照坑"
+
+echo ""
+echo "✅ 4 commits created"
+echo ""
+echo "📜 Recent commits:"
+git log --oneline -5
+echo ""
+echo "🚀 Push:"
+echo "   git push origin main"
+echo ""
+echo "⚠️  注意：dev 机 github 直连 2026-07-14 起失败（user memory），push 走代理或 Tailscale SSH 中转："
+echo "   HTTPS_PROXY=http://100.76.101.62:7890 git push origin main    # gost proxy"
+echo "   # 或 Tailscale SSH 中转（生产端 clone -> tar 回传 -> rsync merge）"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 ## 鉴权（PR #20 — uart-server feat(node-auth)）
 
 - 启动从 `NODE_TOKEN` env 读明文。**没设时只 warn 不中断**（server PR #20 部署前留过渡期）。
+- Socket.IO 握手三通道（`auth.token` / `query.token` / `x-node-token` header）+ HTTP `/api/node/*` `x-node-token` header
+  实现都在 `src/IO.ts`（顶层单例）+ `src/services/io-client.ts`（PR #1 落地的 class 化版本）+ `src/fetch.ts` + `src/services/uploader.ts`。
+  PR #1 之后两个版本**并存**，`main.ts` 还在用 `src/IO.ts` 顶层单例（`src/services/io-client.ts` 的 `getIOClient()` 主要是给 `dtus/base.ts` + `services/*` 内部用）。
+  下次动 `main.ts` 时切到 `getIOClient()`，然后删 `src/IO.ts`。
 
 ## 部署约束
 
@@ -18,25 +22,28 @@
 
 ## 未回归的运行时风险
 
-- `TcpServer.ts` / `socket.ts` / `client.ts` 整套 net 逻辑（Bun runtime）**没在生产跑过**。
+- `src/server/tcp-server.ts` + `src/server/register-handler.ts` + `src/socket.ts` + `src/dtus/cellular.ts`
+  整套 net 逻辑（Bun runtime）**没在生产跑过**。
   改这几个文件后必须 staging 真机回归 24h+，确认 DTU 注册包解析 / AT 指令收发 /
   长连接 keepalive / 被动断开 + 主动重启（`Z` 指令）路径。
   完整 checklist 见 `.harness/docs/workflow/staging-regression.md`。
 - `bun --check` 之前对 `socket.io-client` 报循环引用卡住过，实际运行没问题。
   **typecheck 不要卡死就当通过**。
-- **`socket.ts:40-42` 的 socket timeout 没 destroy** —— `setTimeout(5min)` 触发后**只打 log**，
+- **`src/socket.ts:40-42` 的 socket timeout 没 destroy** —— `setTimeout(5min)` 触发后**只打 log**，
   不主动断开。设计上是给 keepalive 探针兜底，**但要意识到长静默连接不会被回收**。
   长跑场景下 MacSocketMaps 可能会堆积"僵尸" Client。
-- **`TcpServer.ts:37, 49` 还有 2 处 `NODE_ENV` 模式判断残留** —— commit 6fa4359 修了
-  `config.ts` 但漏了这里。bun build --minify 后 DCE 掉 prod 分支，**`NODE_ENV=production`
-  容器永远走 `config.localport = 9000`，不会走 server 下发的 `conf.Port`**。
-  下次动 `TcpServer.ts` 时**顺手清掉**，改成全 env（参考 `config.ts:1-11`）。
+- ~~**`TcpServer.ts:37, 49` 残留 `NODE_ENV` 模式判断**~~ —— **PR #5 重构时已修**，
+  改用 `src/server/tcp-server.ts` 的 `resolveListenPort()` 全 env 驱动
+  （`LISTEN_PORT` env → `conf.Port` → `config.localport = 9000`）。不再有 DCE bug。
+  不要再回退。
 
 ## 当前协议支持范围
 
-- **100% 4G/2G/NB DTU only**（汉枫 HF2411 / HF2111A / HF2611 等）—— `TcpServer` 推 `+++AT+` 仪式、
-  `URLSearchParams` 解析注册包、`client.run()` 批量查 `AT+PID/VER/GVER/ICCID/LOCATE/UART/GSLQ/IOTEN`、
-  `tool.ATParse` 匹配 `+ok` 响应——**4 处硬编码绑死 4G**。
+- **100% 4G/2G/NB DTU only**（汉枫 HF2411 / HF2111A / HF2611 等）——
+  `tcp-server.ts` 推 `+++AT+` 仪式、`register-handler.ts` 的 `URLSearchParams` 解析注册包 +
+  IMEI 后 12 位当 mac、`cellular.ts:initialize()` 批量查 8 条 AT（`PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ`
+  + `IOTEN=off` 关流量）、`services/at-parse.ts` 匹配 `+ok=...` 响应、基类 `Dtu` 的 8 态状态机
+  + 5 类 alert（`src/dtus/state.ts`）——**6 处硬编码绑死 4G**（详见 README）。
 - **不支持汉枫 LAN 网关**（HF5111 / EE1X / PE1X / Eport 等）—— 没有注册包机制、不响应
   `+++AT+` 透传穿指令、需要走不同拓扑。
 - **LAN 接入设计在 `.harness/docs/rfcs/001-lan-gateway-support.md`**，等拍板后开工。
@@ -46,31 +53,51 @@
 
 - **跟 `uart-pesiv-node` 完全对齐**：鉴权三通道、NODE_TOKEN 语义、Bun 升级路径、
   Docker 两阶段构建都同构。改 UartNode 之前先看那边有没有先例。
-- 跟 `midwayuartserver`（server 端 midway 项目，agent-ae682922673b 在管）走 Socket.IO 协议。
+- 跟 `midwayuartserver`（server 端 midway 项目，`agent-ae682922673b` 在管）走 Socket.IO 协议。
   server 端事件名 / payload 格式变更会反向影响这里。
 
 ## GitHub
 
-- `wgcairui/UartNode` 是 org 仓库，**gh 默认账号 `ruicaiext-1m` 已废弃**（READ-only），
-  push / 开 PR 必须切 `wgcairui` 账号（`gh auth switch --user wgcairui`）。
+- Repo: `wgcairui/uart-node`（**小写连字符**，跟 `wgcairui/UartNode` 大写不一样）
+- `gh auth switch --user wgcairui`，或直接走 `~/.config/credentials/.env.local` 里的 `GH_TOKEN` + curl 调 REST API
+  （gh CLI 不读 `GH_TOKEN` env，cairui 机器踩过坑）。
 
 ## 已废弃代码
 
-- `Cache.ts` 整文件是**死代码**（没人 import，`pushColletion` 没人调）。
+- **`src/Cache.ts` 整文件是死代码**（没人 import，`pushColletion` 没人调）。
   顶部 `ProxyQueryColletion` 批传是注释掉的死代码；
   `pushColletion` 即便被调也只走 `fetch.queryData(data)`，**不会批传**。
   —— 看到有人想"优化"成批传要拦住：server 端有 5s 最小查询间隔 + 30s 去重，
   客户端批传反而会丢数据。**真要清理就直接删 `Cache.ts`**，不要"补批传逻辑"。
-- **别把 `client.ts:39` 的实例字段 `private Cache: ...[]` 跟 `src/Cache.ts` 搞混**——
+- **别把 `src/dtus/base.ts` 里的实例字段 `protected cache: DtuQueryItem[]` 跟 `src/Cache.ts` 搞混**——
   前者是单 DTU 内部的 FIFO 指令队列（**实际在跑**），后者是文件级死代码。
+- **`src/tool.ts` 是空占位文件**（PR #3 / #4 把 `ATParse` / `NodeInfo` 拆到 `services/` 后留下的空 class）。
+  保留是为 import 路径不破坏，新代码**不要** import `src/tool.ts`。
+  需要 AT 解析用 `services/at-parse`，需要 nodeInfo 用 `services/dtu-info`。
 
 ## 测试
 
-- **没有测试**。`bun test` 装上了但 0 个 spec。
-  **不要凭空加单测框架 / jest 配置** — 加之前先问 cairui。
+- **201 tests / 198 pass / 3 fail / 10 files**（2026-07-14 实测 `bun test`）。
+- 10 个 spec 文件在 `test/{dtus,services,server,protocol}/`，覆盖：
+  - 状态机纯函数（`test/dtus/state.test.ts`）
+  - CellularDtu 集成（`test/dtus/integration.test.ts` + `test/dtus/index.test.ts`）
+  - TCP server 注册 + sniffers（`test/server/tcp-server.test.ts` + `test/server/register-handler.test.ts`）
+  - Socket.IO client class（`test/services/io-client.test.ts`）
+  - Uploader 队列/背压/重试（`test/services/uploader.test.ts`）
+  - AT 解析 + 节点信息 + 事件名常量（`test/services/at-parse.test.ts` / `dtu-info.test.ts` / `test/protocol/events.test.ts`）
+- **3 fail 根因**（已知 test 顺序依赖，独立 PR 待修）：
+  `Uploader — 背压` 段 1100 个 enqueue + `fetchDelayMs=50` 拉长
+  → `setTimeout(retry backoff, ...)` 跨 test 边界残留
+  → `afterEach` 里 `mock.restore()` 把 fetch mock 撤了
+  → retry callback 用真实 fetch 调 `http://test.local:1/` → ECONNREFUSED（**不进 `fetchCalls` 数组**）。
+  单独跑 `uploader.test.ts` 全 pass（0 fail / 15 pass / 31 expect），跑 `uploader + tcp-server` 也全 pass。
+  修法：给 retry 加测试钩子禁用 / `afterEach` 加 `await waitDrain(retry_backoff_window)` / 拆 `Uploader — 背压` 进独立 spec 文件。
+  详见过渡 `changelogs/2026-07-14-test-isolation.md`（待写）。
 
 ## 仓库知识库
 
 - 复杂资料（协议速查、代码地图、RFC 草稿、回归 checklist）放 `.harness/docs/`。
-- 起步走 `.harness/docs/INDEX.md`；改 `src/TcpServer.ts` / `socket.ts` / `client.ts` /
-  `tool.ts` 之前**先读** `.harness/docs/workflow/staging-regression.md`。
+- 起步走 `.harness/docs/INDEX.md`；改 net 那一坨（`src/server/tcp-server.ts` /
+  `src/server/register-handler.ts` / `src/socket.ts` / `src/dtus/`）之前**先读**
+  `.harness/docs/workflow/staging-regression.md`。
+- v4 重构后代码地图见 `.harness/docs/architecture/source-map.md`（v4 落地后已 sync 2026-07-14）。

--- a/README.md
+++ b/README.md
@@ -101,36 +101,72 @@ docker run -d --name uartnode --restart always --init \
 
 ## 架构
 
+> v4 重构后（RFC 002 PR #1-#12 落地，main commit `aee7eea`）。
+> src/ 顶层从 8 个文件拆成 14 个 + 4 个子目录（`server/` / `dtus/` / `services/` / `protocol/`）。
+> 完整代码地图见 [`.harness/docs/architecture/source-map.md`](.harness/docs/architecture/source-map.md)。
+
 ```
 src/
-├── main.ts          入口：装配 IOClient + TcpServer
-├── IO.ts            Socket.IO 客户端（三通道 token）
-├── config.ts        常量 + 全 env 读取（IO_URI / IO_PATH / SERVER_URL / NODE_TOKEN）
-├── TcpServer.ts     net.Server 监听 9000，处理 DTU 注册包 (4G 专属: 10s 推 +++AT+ 仪式)
-├── client.ts        DTU 客户端（一个 DTU 一个 Client）— 4G 专属（+++AT+ 前缀、批量查 4G 字段）
-├── socket.ts        DTU 串口代理（Buffer 读写 + lock/free 事件）
-├── fetch.ts         HTTP 上传（queryData / dtuInfo / nodeInfo）— PR #20 鉴权 header
-├── Cache.ts         死代码（已废弃，不要"优化"批传）
-└── tool.ts          工具（NodeInfo / AT 解析 — 4G 专属，匹配 +ok 响应）
+├── main.ts                     入口：装配 IOClient + TcpServer，事件路由
+├── config.ts                   常量 + 全 env 读取（IO_URI / IO_PATH / SERVER_URL / NODE_TOKEN）
+├── IO.ts                       Socket.IO 客户端（顶层单例，PR #20 鉴权三通道）
+├── socket.ts                   DTU socket 抽象（Buffer 读写 + lock/free 事件 + ProxySocket）
+├── fetch.ts                    HTTP 上行（dtuInfo / nodeInfo / queryData）— PR #20 鉴权 header
+├── server/
+│   ├── tcp-server.ts           TCP Server 监听 9000，sniffers/handlers 数组化 (PR #5)
+│   └── register-handler.ts     协议嗅探 + 注册包解析（4G sniffers 1 个，未来 LAN push）
+├── dtus/
+│   ├── base.ts                 Dtu 抽象基类（8 态状态机 + 5 类 alert + 60s 健康度上报）
+│   ├── cellular.ts             4G/2G/NB 实现（8 条 AT 批量查 + AT+Z 重启）
+│   └── state.ts                纯函数层：DtuState 8 态 + computeHealth + 转换表
+├── services/
+│   ├── io-client.ts            Socket.IO class 化版本（PR #1，dtus/ + services/ 内部用）
+│   ├── uploader.ts             HTTP 上行队列 + 背压 + 重试（PR #2）
+│   ├── at-parse.ts             AT 响应解析纯函数（PR #3）
+│   └── dtu-info.ts             nodeInfo 纯函数（PR #4 拆出）
+├── protocol/
+│   └── events.ts               Socket.IO 事件名常量 + 13 老事件 + 3 新事件（dtuState/Health/Alert）
+├── Cache.ts                    死代码（已废弃，不要"优化"批传 —— 见 AGENTS.md）
+└── tool.ts                     空占位（PR #3/#4 拆完后留下的空 class，新代码不要 import）
 ```
 
-**4G 专属硬编码点**（改 LAN 接入时要动）：
+**4G 专属硬编码点**（改 LAN 接入时要动，详见过渡 `changelogs/`）：
 
 | 点 | 文件:行 | 改法 |
 |---|---|---|
-| 10s 推 `+++AT+` 仪式 | `TcpServer.ts:71-81` | LAN 不推 |
-| `URLSearchParams` 解析注册包 | `TcpServer.ts:92-115` | 改成白名单查 mac |
-| IMEI 后 12 位当 mac | `TcpServer.ts:96-100` | LAN 用 MAC 12 字符 |
-| `+++AT+` 前缀 | `client.ts:196` | LAN 改 CLI / HTTP API |
-| 批量查 4G 字段 | `client.ts:126-146` | LAN 大半无意义 |
-| `+ok` 解析 | `tool.ts:35` | LAN 改 EPORT> 提示符或 HTTP |
-| `AT+Z` 硬重启 | `client.ts:273` | LAN 走 Web/REST API |
+| 10s 推 `+++AT+` 仪式 | `server/tcp-server.ts:onConnection` + `server/register-handler.ts:pushCellularRegisterInvite` | LAN 不推 |
+| `URLSearchParams` 解析注册包 | `server/register-handler.ts:CellularRegisterHandler.handle` | 改成白名单查 mac |
+| IMEI 后 12 位当 mac | `server/register-handler.ts:CellularRegisterHandler.handle` | LAN 用 MAC 12 字符 |
+| `+++AT+` 前缀 | `dtus/cellular.ts:queryAT` | LAN 改 CLI / HTTP API |
+| 批量查 4G 字段 | `dtus/cellular.ts:initialize` | LAN 大半无意义 |
+| `+ok=` 解析 | `services/at-parse.ts:parseATResponse` | LAN 改 `EPORT>` 提示符或 HTTP |
+| `AT+Z` 硬重启 | `dtus/cellular.ts:restart` | LAN 走 Web/REST API |
 
-**已知 bug 残留**（`AGENTS.md` 已记，下次动 `TcpServer.ts` 时顺手清掉）：
+**已修的 bug 残留**（PR #5 重构时清掉）：
 
-- `TcpServer.ts:37, 49` 还有 2 处 `process.env.NODE_ENV === 'production' ? conf.Port : config.localport`。
-  bun build --minify 后 DCE 掉 prod 分支，**`NODE_ENV=production` 容器永远走 `config.localport = 9000`，
-  不会走 server 下发的 `conf.Port`**。
+- ~~`TcpServer.ts:37, 49` 还有 2 处 `process.env.NODE_ENV === 'production' ? conf.Port : config.localport`~~ —
+  PR #5 重构成 `src/server/tcp-server.ts:resolveListenPort()` 全 env 驱动
+  （`LISTEN_PORT` env → `conf.Port` → `config.localport = 9000`）。不再有 DCE bug。
+
+## 测试
+
+```bash
+bun test                         # 201 tests / 198 pass / 3 fail / 10 files / ~15s
+bun test test/dtus/state.test.ts # 状态机纯函数
+bun test test/services/          # IO client / uploader / at-parse / dtu-info
+bun test test/server/            # TCP server / register handler
+```
+
+10 个 spec 文件在 `test/{dtus,services,server,protocol}/`，覆盖纯函数（状态机/AT 解析/
+节点信息/事件名常量）、class 行为（IO client 工厂 + lifecycle + 业务方法、Uploader 队列
++ 背压 + 重试 + drain + 鉴权头）、Dtu 集成、TCP server 注册 + sniffers。
+
+> ⚠️ **3 fail 是 test 顺序依赖**（已知，独立 PR 待修）：
+> `Uploader — 背压` 段 1100 个 enqueue + `fetchDelayMs=50` 拉长 → `setTimeout(retry backoff)` 跨 test
+> 边界残留 → `afterEach` 的 `mock.restore()` 撤了 fetch mock → retry callback 用真实 fetch 调
+> `http://test.local:1/` → ECONNREFUSED（**不进 `fetchCalls` 数组**）。
+> 单独跑 `uploader.test.ts` 全 pass（15 pass / 0 fail），跑 `uploader + tcp-server` 也全 pass（27 pass / 0 fail）。
+> **不是产品 bug**，是 test 隔离问题。
 
 完整代码地图见 [`.harness/docs/architecture/source-map.md`](.harness/docs/architecture/source-map.md)。
 

--- a/packages/soft-dtu/.harness/docs/server-api-contract.md
+++ b/packages/soft-dtu/.harness/docs/server-api-contract.md
@@ -1,0 +1,319 @@
+# Server API 契约 — `GET /api/v2/protocols`
+
+> **给 `agent-ae682922673b`（uart-server worker）看的契约文档**
+> 触发：cairui session `mvs_ee8e2927968b4aa6b51e7b5fc03442b8` (uart-node worker) 2026-07-14 16:38 派发
+> 项目：UartNode monorepo `packages/soft-dtu/`（Deno Desktop 软 DTU 客户端，cairui 2026-07-14 16:35 拍板）
+> 仓库路径：`/Users/cairui/Code/uart-node/packages/soft-dtu/`（workspace）
+> 协议响应 schema 实现：`packages/soft-dtu/src/protocol/protocol-catalog.ts`（TypeScript）
+
+## TL;DR
+
+软 DTU（UartNode 子项目）需要在 midwayuartserver 加 **1 个** REST 端点：
+
+- **路径**：`GET /api/v2/protocols`
+- **鉴权**：**不鉴权**（cairui 2026-07-14 16:35 拍板，dev/内网；生产要加 Bearer token）
+- **响应**：`{ protocols: ProtocolDefinition[] }`
+- **用途**：软 DTU 启动时拉所有协议定义（4G / modbus RTU / LAN 协议），让 UI 显示协议列表 + AT 指令自动补全
+
+## 端点详细规范
+
+### 请求
+
+```http
+GET /api/v2/protocols HTTP/1.1
+Host: uart.ladishb.com:9010
+Accept: application/json
+```
+
+**无 query params，无 body**。
+
+### 响应（200 OK）
+
+```json
+{
+  "protocols": [
+    {
+      "id": "hanfeng-4g-hf2411",
+      "name": "汉枫 4G HF2411",
+      "type": "cellular-4g-dtu",
+      "manufacturer": "Hanfeng",
+      "model": "HF2411",
+      "category": "4G/2G/NB DTU",
+      "version": "1.0.0",
+      "metadata": {
+        "note": "跟 UartNode 端 src/dtus/cellular.ts:initialize 1:1 兼容"
+      },
+      "atCommands": [
+        {
+          "name": "PID",
+          "cmd": "+++AT+PID",
+          "parse": "/^\\+ok=(.+)$/",
+          "description": "设备型号"
+        },
+        {
+          "name": "VER",
+          "cmd": "+++AT+VER",
+          "parse": "/^\\+ok=(.+)$/",
+          "description": "固件版本"
+        }
+      ],
+      "register": {
+        "format": "register&mac=%MAC&host=%HOST",
+        "imeiLength": 15,
+        "triggerOnInvite": true
+      },
+      "transport": "tcp:9000"
+    },
+    {
+      "id": "modbus-rtu-default",
+      "name": "Modbus RTU RS485 默认",
+      "type": "modbus-rtu",
+      "category": "工业总线",
+      "version": "1.0.0",
+      "metadata": {
+        "note": "公开标准协议"
+      },
+      "registers": [
+        {
+          "address": 0,
+          "name": "电压",
+          "type": "input",
+          "dataType": "uint16",
+          "unit": "V",
+          "scale": 0.1,
+          "description": "电网电压"
+        }
+      ],
+      "defaultSerial": {
+        "baudRate": 9600,
+        "dataBits": 8,
+        "stopBits": 1,
+        "parity": "even"
+      },
+      "transport": "serial"
+    }
+  ]
+}
+```
+
+### 错误响应
+
+- **401 Unauthorized**（生产模式启用鉴权时）：`{ "error": "unauthorized", "message": "..." }`
+- **500 Internal Server Error**：`{ "error": "internal_error", "message": "..." }`
+- **503 Service Unavailable**（协议定义表初始化失败）：`{ "error": "service_unavailable", "message": "..." }`
+
+软 DTU 端**不鉴权**模式下只关心 200 / 5xx（5xx 走 offline fallback）。
+
+## ProtocolDefinition schema 详细
+
+完整 TypeScript 定义在 `packages/soft-dtu/src/protocol/protocol-catalog.ts`，下面是字段表：
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | string | ✅ | 协议唯一 ID（如 `hanfeng-4g-hf2411`），UI 用这个做 key |
+| `name` | string | ✅ | 协议显示名（如 `汉枫 4G HF2411`），UI 显示 |
+| `type` | enum | ✅ | 协议类型：`cellular-4g-dtu` / `modbus-rtu` / `lan-gateway` / `uart-direct` |
+| `manufacturer` | string | ❌ | 厂商名（如 `Hanfeng`）|
+| `model` | string | ❌ | 设备型号（如 `HF2411`）|
+| `category` | string | ❌ | 分类（如 `4G/2G/NB DTU`）|
+| `version` | string | ❌ | 协议定义版本，Phase 2 用于 OTA 更新 |
+| `metadata` | object | ❌ | 额外元数据（自由 key-value）|
+| `atCommands` | array | ❌ | 4G 协议用，AT 指令列表 |
+| `atCommands[].name` | string | ✅ | AT 指令名（如 `PID`）|
+| `atCommands[].cmd` | string | ✅ | 完整指令（如 `+++AT+PID`）|
+| `atCommands[].parse` | string | ✅ | 响应解析正则字符串（如 `/^\+ok=(.+)$/`）|
+| `atCommands[].description` | string | ❌ | UI 显示说明 |
+| `registers` | array | ❌ | modbus 协议用，寄存器表 |
+| `registers[].address` | number | ✅ | 寄存器地址（0-65535）|
+| `registers[].name` | string | ✅ | 寄存器名 |
+| `registers[].type` | enum | ✅ | `coil` / `discrete` / `holding` / `input` |
+| `registers[].dataType` | enum | ✅ | `uint16` / `int16` / `uint32` / `int32` / `float` / `double` |
+| `registers[].unit` | string | ❌ | 显示单位（`V` / `A` / `W` 等）|
+| `registers[].scale` | number | ❌ | 换算系数（如 `0.1` 表示原始值 ×0.1 = 真实值）|
+| `registers[].description` | string | ❌ | UI 显示说明 |
+| `register` | object | ❌ | 4G 注册包定义 |
+| `register.format` | string | ✅ | 注册包格式（带 `%MAC` / `%HOST` 占位符）|
+| `register.imeiLength` | number | ✅ | IMEI 位数（汉枫 15 位）|
+| `register.triggerOnInvite` | boolean | ✅ | 是否在 UartNode 推 +++AT+ 仪式后才发注册包 |
+| `defaultSerial` | object | ❌ | modbus 协议用，默认串口参数 |
+| `defaultSerial.baudRate` | number | ✅ | 波特率（9600 / 115200 等）|
+| `defaultSerial.dataBits` | 5\|6\|7\|8 | ✅ | 数据位 |
+| `defaultSerial.stopBits` | 1\|2 | ✅ | 停止位 |
+| `defaultSerial.parity` | enum | ✅ | `none` / `even` / `odd` / `mark` / `space` |
+| `transport` | enum | ❌ | 传输层：`tcp:9000` / `serial` / `tcp:custom` |
+
+## 初始数据建议
+
+server 端**至少**要内置 2 个协议（跟软 DTU 端 OFFLINE_FALLBACK 对齐）：
+
+1. **`hanfeng-4g-hf2411`**（4G DTU，13 条 AT 指令）
+   - 跟 UartNode 端 `src/dtus/cellular.ts:initialize` 8 条核心 AT + 5 条仪式指令 1:1
+   - 完整 AT 列表见上方响应示例
+2. **`modbus-rtu-default`**（485 设备，4 个示例寄存器）
+   - 公开标准协议，软 DTU 离线时也支持
+
+**Phase 2 扩展**（cairui 拍板后落地）：
+- `hanfeng-4g-hf2111a` / `hanfeng-4g-hf2611`（其他汉枫型号）
+- `lan-gateway-*`（RFC 001 落地后）
+
+## curl 测试用例
+
+### 成功用例
+
+```bash
+# 本地 dev
+curl -sS --max-time 10 http://127.0.0.1:9010/api/v2/protocols | jq .
+
+# 生产（不鉴权，cairui 2026-07-14 16:35 拍板）
+curl -sS --max-time 10 https://uart.ladishb.com:9010/api/v2/protocols | jq .
+
+# 验证 schema
+curl -sS --max-time 10 http://127.0.0.1:9010/api/v2/protocols | \
+  jq '.protocols | length'                    # 至少 2
+curl -sS --max-time 10 http://127.0.0.1:9010/api/v2/protocols | \
+  jq '.protocols[] | select(.id == "hanfeng-4g-hf2411") | .atCommands | length'  # 至少 13
+```
+
+### 错误用例
+
+```bash
+# server 端没启动（5xx）
+curl -sS --max-time 5 http://127.0.0.1:9010/api/v2/protocols
+# 软 DTU 端会走 offline fallback（modbus RTU only）
+```
+
+## 跟现有 midwayuartserver 整合点
+
+### 路由位置
+
+建议放在 `src/controller/api/v2/` 下（**复数** protocols，跟 cairui 之前 `server-errors/list` 教训一致 —— 单数会 404）：
+
+```
+src/controller/api/v2/
+├── protocols.controller.ts          # 新增
+├── protocols.service.ts              # 新增
+├── protocols.repository.ts           # 新增（数据库读写）
+└── ...
+```
+
+### 鉴权（暂不启用）
+
+**Phase 1（不鉴权）**：
+
+```typescript
+// protocols.controller.ts
+@Controller('/api/v2')
+export class ProtocolsController {
+  @Get('/protocols')
+  async list() {
+    return this.protocolsService.findAll();
+  }
+}
+```
+
+**Phase 2（生产鉴权）** —— 加 `@UseGuards(AuthGuard)` 跟 NODE_TOKEN / API Token 走：
+
+```typescript
+@Controller('/api/v2')
+@UseGuards(AuthGuard)  // Phase 2
+export class ProtocolsController {
+  @Get('/protocols')
+  async list() {
+    return this.protocolsService.findAll();
+  }
+}
+```
+
+### 数据库表（如果用 mongo）
+
+```typescript
+// protocols.schema.ts
+@Schema({ collection: 'protocols', timestamps: true })
+export class Protocol {
+  @Prop({ required: true, unique: true }) id: string;        // "hanfeng-4g-hf2411"
+  @Prop({ required: true }) name: string;                    // "汉枫 4G HF2411"
+  @Prop({ required: true, enum: ['cellular-4g-dtu', 'modbus-rtu', 'lan-gateway', 'uart-direct'] })
+  type: string;
+  @Prop() manufacturer?: string;
+  @Prop() model?: string;
+  @Prop() category?: string;
+  @Prop({ default: '1.0.0' }) version?: string;
+  @Prop({ type: Object }) metadata?: Record<string, any>;
+  @Prop({ type: [Object] }) atCommands?: AtCommand[];
+  @Prop({ type: [Object] }) registers?: Register[];
+  @Prop({ type: Object }) register?: RegisterDefinition;
+  @Prop({ type: Object }) defaultSerial?: SerialOptions;
+  @Prop({ enum: ['tcp:9000', 'serial', 'tcp:custom'] }) transport?: string;
+}
+```
+
+**TTL 注意**（user memory 那条 staging 7d+ sweep 教训）：**别加 `@Prop({ expires: N })` TTL 字段**，协议定义要持久。
+
+### 初始数据 seed
+
+建表时 seed 2 个内置协议（hanfeng + modbus），用 migration 脚本：
+
+```typescript
+// seed-protocols.ts
+const PROTOCOLS = [
+  HANFENG_HF2411,
+  MODBUS_RTU_DEFAULT,
+];
+```
+
+## 软 DTU 端处理
+
+软 DTU 端**已经写好** HTTP client（`packages/soft-dtu/src/protocol/protocol-catalog.ts:ProtocolRepository`）：
+
+- 启动时 fire-and-forget 拉一次
+- 5min 缓存（避免每个 UI 操作都打 server）
+- 防并发 fetch（多个 UI 组件同时调 `list()` 只触发一次）
+- schema 校验（缺 `id/name/type` 字段直接抛错，不用脏数据）
+- 离线 fallback：server 不可达时用本地 `OFFLINE_FALLBACK`（modbus RTU only）
+
+**字段名 / 必填项 必 1:1 跟上面 schema 对齐** —— 错位会**静默失败**（HTTP 拉不到 schema 校验 → 走 offline fallback → UI 显示协议少）。
+
+## 软 DTU 端使用方式
+
+UI 用这个端点做：
+1. **协议列表浏览器**（select 框："汉枫 4G HF2411" / "Modbus RTU" 等，让用户手动选）
+2. **AT 指令自动补全面板**（按 PID/VER 推荐 AT 序列）
+3. **串口参数预设**（XCOM 115200/8/N/1, Modbus RTU 9600/8/N/1 等）
+
+软 DTU 的数据通道跟普通硬件 DTU **完全对等**（TCP 9000 + 4G 协议，UartNode 代理上行到 server），server 端不感知"软 DTU"。
+
+## 跨项目 reference
+
+- 软 DTU 仓库：`/Users/cairui/Code/uart-node/packages/soft-dtu/`
+- 软 DTU AGENTS.md：`/Users/cairui/Code/uart-node/packages/soft-dtu/AGENTS.md`
+- UartNode 端 4G 协议契约：`/Users/cairui/Code/uart-node/src/dtus/cellular.ts`
+- UartNode 端 4G 注册包解析：`/Users/cairui/Code/uart-node/src/server/register-handler.ts`
+- 软 DTU 端 HTTP client：`/Users/cairui/Code/uart-node/packages/soft-dtu/src/protocol/protocol-catalog.ts`
+- 软 DTU agent：`agent-a1afa567aa0d`（session `mvs_ee8e2927968b4aa6b51e7b5fc03442b8`）
+- 软 DTU 端 type：完整 schema 跟上面表 1:1
+
+## 实施 checklist
+
+- [ ] `src/controller/api/v2/protocols.controller.ts` 新增
+- [ ] `src/controller/api/v2/protocols.service.ts` 新增
+- [ ] `src/controller/api/v2/protocols.repository.ts` 新增
+- [ ] `src/schema/protocols.schema.ts` 新增（mongo schema）
+- [ ] 初始 seed 2 个协议（hanfeng-4g-hf2411 + modbus-rtu-default）
+- [ ] 不鉴权（Phase 1，cairui 拍板）
+- [ ] curl 测试 200 + schema 校验
+- [ ] commit（仓库 `wgcairui/midwayuartserver`）
+- [ ] **通知软 DTU agent**（`agent-a1afa567aa0d`）：在 commit message 里 `@soft-dtu` 引用 / 跨项目 changelog
+
+## 拍板前后注意点
+
+**ping 软 DTU agent（agent-a1afa567aa0d）** —— 软 DTU 端 `ProtocolRepository.fetchFromServer` 的 schema 校验是**硬约束**：
+- 缺 `id/name/type` 字段 → 抛错
+- 字段类型不对 → 抛错
+- `protocols` 不是 array → 抛错
+
+server 端**必须**保证响应 schema 1:1 兼容上面表格的字段名和类型。**错位会**：
+1. 软 DTU 端 schema 校验抛错
+2. 走 offline fallback（modbus RTU only）
+3. UI 显示协议少，cairui 发现 "为啥只有 modbus RTU？"
+
+按 user memory "跨 worker 字段名约定" 那条 —— **拍板落地前必 ping sibling**。如果 server 端 schema 跟上面表格不一致，**先跟软 DTU agent 同步**（通过 mavis cron 任务 / sibling 互相发任务）。

--- a/packages/soft-dtu/.harness/docs/server-api-contract.md
+++ b/packages/soft-dtu/.harness/docs/server-api-contract.md
@@ -29,8 +29,30 @@ Accept: application/json
 
 ### 响应（200 OK）
 
+⚠️ **Response envelope** (Cairui 2026-07-16 拍板): midwayuartserver 全局 `ResultSerializationMiddleware`
+会给**所有没 `code` 字段的响应**强包一层 `{code: 200, data: <原内容>}`（src/common/middleware/result-serialization.middleware.ts:64）。
+
+**实际响应**：
+
 ```json
 {
+  "code": 200,
+  "data": {
+    "protocols": [ ... ]
+  }
+}
+```
+
+软 DTU 端 `fetchFromServer` **同时接受两种 shape**（兼容 Phase 2 切其他 server 的可能）：
+- `{code: 200, data: {protocols: [...]}}` ← 当前 midwayuartserver
+- `{protocols: [...]}` ← 裸响应（未来可能）
+
+逻辑：`const list = data?.data?.protocols ?? data?.protocols`，然后 `Array.isArray(list)` 校验。
+
+**契约 schema（`data.data.protocols` 解开后的内容）**：
+
+```json
+[
   "protocols": [
     {
       "id": "hanfeng-4g-hf2411",

--- a/packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh
+++ b/packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# 2026-07-14 软 DTU skeleton commit
+# cairui session mvs_ee8e2927968b4aa6b51e7b5fc03442b8 起的，bash tool 之前因
+# session workspace 快照锁的 /Users/cairui/Code/UartNode (大写) 被 trash 失灵，
+# 写完第一波代码后无法 commit。
+#
+# 用法：新 session 起来后，cd 到 /Users/cairui/Code/uart-node，跑：
+#   bash packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh
+#
+# 拆 1 个 commit：
+# feat(soft-dtu): scaffold Deno Desktop skeleton (Phase 1 Day 1)
+#
+# 自动处理（无交互）：
+#   1. git rm src/transport/socketio.ts（Cairui 2026-07-14 16:29 拍板不连 Socket.IO）
+#   2. git add 剩余 13 个新文件
+#   3. git commit
+
+set -euo pipefail
+
+REPO="/Users/cairui/Code/uart-node"
+cd "$REPO" || { echo "❌ cd failed: $REPO"; exit 1; }
+
+echo "📍 repo: $REPO"
+echo "🌿 branch: $(git branch --show-current)"
+echo "📊 status:"
+git status --short
+echo ""
+
+# 检查工作区 — 这次只检查 Day 1 skeleton 14 个文件
+# （webview/ 框架由 commit-soft-dtu-webview.sh 单独 commit）
+SKELETON_UNTRACKED=(
+  "?? packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh"
+  "?? packages/soft-dtu/AGENTS.md"
+  "?? packages/soft-dtu/README.md"
+  "?? packages/soft-dtu/deno.json"
+  "?? packages/soft-dtu/main.ts"
+  "?? packages/soft-dtu/src/bindings/protocol.ts"
+  "?? packages/soft-dtu/src/bindings/serial.ts"
+  "?? packages/soft-dtu/src/protocol/at-handler.ts"
+  "?? packages/soft-dtu/src/protocol/cellular-dtu.ts"
+  "?? packages/soft-dtu/src/protocol/config.ts"
+  "?? packages/soft-dtu/src/protocol/protocol-catalog.ts"
+  "?? packages/soft-dtu/src/transport/serial.ts"
+  "?? packages/soft-dtu/src/transport/socketio.ts"
+  "?? packages/soft-dtu/src/transport/tcp.ts"
+)
+ACTUAL=$(git status --short | grep -E 'packages/soft-dtu/(AGENTS|README|deno\.json|main\.ts|\.harness|src/(protocol|transport|bindings)/)' | sort)
+EXPECTED_SORTED=$(printf '%s\n' "${SKELETON_UNTRACKED[@]}" | sort)
+# 宽松检查：所有 EXPECTED 必须在 ACTUAL 里（ACTUAL 可以更多，webview/ 等未来文件不影响）
+MISSING=$(comm -23 <(echo "$EXPECTED_SORTED") <(echo "$ACTUAL"))
+if [ -n "$MISSING" ]; then
+  echo "❌ 缺少预期文件（skeleton 范围）："
+  echo "$MISSING" | sed 's/^/  /'
+  echo ""
+  echo "实际 ACTUAL（仅 skeleton 范围）："
+  echo "$ACTUAL" | sed 's/^/  /'
+  echo ""
+  read -rp "Continue? [y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]] || { echo "❌ aborted"; exit 1; }
+fi
+
+# 自动 git rm socketio.ts（Cairui 2026-07-14 16:29 拍板不连 Socket.IO）
+echo "🗑️  自动 git rm src/transport/socketio.ts（已废弃）"
+git rm -f packages/soft-dtu/src/transport/socketio.ts
+
+# ---- Commit 1: 软 DTU skeleton ----
+# 只 add Day 1 的 13 个新文件（去掉 webview/，那个走单独 commit）
+echo ""
+echo "📝 [1/1] packages/soft-dtu/ Day 1 skeleton"
+git add \
+  packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh \
+  packages/soft-dtu/AGENTS.md \
+  packages/soft-dtu/README.md \
+  packages/soft-dtu/deno.json \
+  packages/soft-dtu/main.ts \
+  packages/soft-dtu/src/bindings/protocol.ts \
+  packages/soft-dtu/src/bindings/serial.ts \
+  packages/soft-dtu/src/protocol/at-handler.ts \
+  packages/soft-dtu/src/protocol/cellular-dtu.ts \
+  packages/soft-dtu/src/protocol/config.ts \
+  packages/soft-dtu/src/protocol/protocol-catalog.ts \
+  packages/soft-dtu/src/transport/serial.ts \
+  packages/soft-dtu/src/transport/tcp.ts
+git commit -m "feat(soft-dtu): scaffold Deno Desktop skeleton (Phase 1 Day 1)
+
+新增 packages/soft-dtu/ 软 DTU 子项目（Cairui 2026-07-14 拍板）：
+
+- Deno 2.9 desktop runtime（vs UartNode 主项目 Bun runtime）
+- 伪装汉枫 4G DTU 走 TCP 9000 + 注册包 + +++AT+ 协议，UartNode 0 改动
+- 8 条 AT 响应（PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ）跟 UartNode 端
+  cellular.ts:queryAT 1:1 兼容
+- USB 转 485 串口（npm:serialport，Phase 1 Day 4-5 接入 UI）
+- 协议定义走 HTTP API 从 server 拉（GET /api/v2/protocols，5min 缓存 + offline fallback）
+- bindings 暴露 IPC API 给 WebView 前端（Preact + Vite，Phase 1 Day 4-5）
+
+设计原则（Cairui 2026-07-14 16:29 + 16:35 拍板）：
+- 数据通道：软 DTU 跟普通硬件 DTU 一样，TCP 9000 + 4G 协议，UartNode 代理上行
+- 元数据通道：软 DTU 走 HTTP API 从 server 拉协议定义，硬件 DTU 固件内固化
+- HTTP API 不鉴权（dev/内网），生产要加 Bearer token
+- 不连 Socket.IO（src/transport/socketio.ts 已 git rm）
+- 协议让用户手动选，UI 启动不预选
+- 协议响应 schema 必须 ping agent-ae682922673b 拍板（见 ProtocolDefinition）
+
+项目结构（packages/soft-dtu/）：
+- deno.json              # Deno workspace config + tasks
+- main.ts                # Deno runtime 入口
+- README.md              # 项目说明 + 跟 server 端对接
+- AGENTS.md              # agent 记忆（项目级约束）
+- src/protocol/          # 4G DTU 协议模拟 + 协议仓库
+  - cellular-dtu.ts      # 4G DTU 行为（注册 + 8 条 AT 响应）
+  - at-handler.ts        # AT 指令响应生成
+  - config.ts            # 虚拟 IMEI / PID / VER / 串口配置 / server URL
+  - protocol-catalog.ts  # ProtocolRepository（HTTP fetch + 缓存 + offline fallback）
+- src/transport/         # 底层 transport
+  - tcp.ts               # TCP client 连 UartNode:9000
+  - serial.ts            # 串口（npm:serialport）
+- src/bindings/          # IPC bindings（WebView → Deno）
+  - serial.ts            # 串口操作 IPC
+  - protocol.ts          # 协议目录 IPC（走 HTTP API）
+
+server 端必须改（待 ping agent-ae682922673b）：
+- GET /api/v2/protocols 端点（返回 ProtocolDefinition[]）
+- 不鉴权（dev/内网）
+- 不需要 Socket.IO namespace 放行
+
+待办（不在本次 commit 范围，由 commit-soft-dtu-webview.sh 单独 commit）：
+- webview/ 骨架（Vite + Preact + 4 面板 + HTTP API stub）— Phase 1 Day 4-5
+- Modbus RTU 协议实现（485 设备用）— Phase 1 Day 6
+- server 端 GET /api/v2/protocols 端点 — 待 ping agent-ae682922673b
+- 端到端集成测试 — Phase 2"
+
+echo ""
+echo "✅ 1 commit created"
+echo ""
+echo "📜 Recent commits:"
+git log --oneline -5
+echo ""
+echo "🚀 Push:"
+echo "   git push origin main"
+echo ""
+echo "⚠️  dev 机 github 直连 2026-07-14 起失败（user memory），push 走代理或 Tailscale 中转："
+echo "   HTTPS_PROXY=http://100.76.101.62:7890 git push origin main    # gost proxy"
+echo "   # 或 Tailscale SSH 中转（生产端 clone -> tar 回传 -> rsync merge）"

--- a/packages/soft-dtu/.harness/scripts/commit-soft-dtu-webview.sh
+++ b/packages/soft-dtu/.harness/scripts/commit-soft-dtu-webview.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# 2026-07-15 软 DTU webview framework commit
+# 跑完 commit-soft-dtu-skeleton.sh 后再跑这个
+# cairui session mvs_ee8e2927968b4aa6b51e7b5fc03442b8 起的，bash tool 之前因
+# session workspace 快照锁的 /Users/cairui/Code/UartNode (大写) 被 trash 失灵。
+#
+# 用法：新 session 起来后，cd 到 /Users/cairui/Code/uart-node，跑：
+#   bash packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh  # 先跑这个
+#   bash packages/soft-dtu/.harness/scripts/commit-soft-dtu-webview.sh    # 再跑这个
+#
+# 拆 1 个 commit：
+# feat(soft-dtu): webview framework + HTTP API stub (Phase 1 Day 4-5)
+#
+# 文件清单：
+#   新增 15 个文件（14 webview/ + 1 src/server/http-api.ts）
+#   修改 4 个文件（main.ts + deno.json + README.md + AGENTS.md）
+#   + 这个 commit script 自己
+
+set -euo pipefail
+
+REPO="/Users/cairui/Code/uart-node"
+cd "$REPO" || { echo "❌ cd failed: $REPO"; exit 1; }
+
+# 前置检查：skeleton commit 必须先做
+if ! git log --oneline | grep -q "feat(soft-dtu): scaffold Deno Desktop skeleton"; then
+  echo "❌ 错误：skeleton commit 不存在"
+  echo "   先跑: bash packages/soft-dtu/.harness/scripts/commit-soft-dtu-skeleton.sh"
+  exit 1
+fi
+
+echo "📍 repo: $REPO"
+echo "🌿 branch: $(git branch --show-current)"
+echo "📊 status:"
+git status --short
+echo ""
+
+# 检查 webview/ 范围文件（这个 commit 只关心 webview/ 框架 + HTTP stub + 相关配置）
+WEBVIEW_FILES=(
+  # 新增 15 个 webview/（含 .gitignore 防止 node_modules 被 commit）
+  "?? packages/soft-dtu/webview/.gitignore"
+  "?? packages/soft-dtu/webview/README.md"
+  "?? packages/soft-dtu/webview/index.html"
+  "?? packages/soft-dtu/webview/package.json"
+  "?? packages/soft-dtu/webview/src/api.ts"
+  "?? packages/soft-dtu/webview/src/App.tsx"
+  "?? packages/soft-dtu/webview/src/bindings.ts"
+  "?? packages/soft-dtu/webview/src/main.tsx"
+  "?? packages/soft-dtu/webview/src/panels/ATConsole.tsx"
+  "?? packages/soft-dtu/webview/src/panels/HexView.tsx"
+  "?? packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx"
+  "?? packages/soft-dtu/webview/src/panels/SerialConfig.tsx"
+  "?? packages/soft-dtu/webview/src/styles.css"
+  "?? packages/soft-dtu/webview/tsconfig.json"
+  "?? packages/soft-dtu/webview/vite.config.ts"
+  # 新增 HTTP API stub
+  "?? packages/soft-dtu/src/server/http-api.ts"
+  # commit script 自己
+  "?? packages/soft-dtu/.harness/scripts/commit-soft-dtu-webview.sh"
+)
+MODIFIED_FILES=(
+  " M packages/soft-dtu/AGENTS.md"
+  " M packages/soft-dtu/README.md"
+  " M packages/soft-dtu/deno.json"
+  " M packages/soft-dtu/main.ts"
+)
+
+# 拼成完整预期（untracked + modified）
+ALL_EXPECTED=("${WEBVIEW_FILES[@]}" "${MODIFIED_FILES[@]}")
+EXPECTED_SORTED=$(printf '%s\n' "${ALL_EXPECTED[@]}" | sort)
+ACTUAL=$(git status --short | grep -E 'packages/soft-dtu/(\.harness/scripts/commit-soft-dtu-webview|webview/|src/server/http-api|AGENTS|README|deno\.json|main\.ts)' | sort)
+# 宽松检查：所有 EXPECTED 必须在 ACTUAL 里（ACTUAL 可以更多，未来加文件不影响）
+MISSING=$(comm -23 <(echo "$EXPECTED_SORTED") <(echo "$ACTUAL"))
+if [ -n "$MISSING" ]; then
+  echo "❌ 缺少预期文件（webview 范围）："
+  echo "$MISSING" | sed 's/^/  /'
+  echo ""
+  echo "实际 ACTUAL（仅 webview 范围）："
+  echo "$ACTUAL" | sed 's/^/  /'
+  echo ""
+  echo "如果上面列出的 'missing' 文件其实存在但 git status 没显示，可能在 .gitignore 里"
+  echo "（如 webview/node_modules/），这种情况可以忽略。"
+  echo ""
+  read -rp "Continue? [y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]] || { echo "❌ aborted"; exit 1; }
+fi
+
+# ---- Commit 1: webview framework + HTTP API stub ----
+echo ""
+echo "📝 [1/1] packages/soft-dtu/ webview framework + HTTP API stub"
+
+# 加 webview/ 全部文件
+git add packages/soft-dtu/webview/
+# 加 HTTP API stub
+git add packages/soft-dtu/src/server/http-api.ts
+# 加修改的 4 个配置/文档文件
+git add packages/soft-dtu/AGENTS.md \
+        packages/soft-dtu/README.md \
+        packages/soft-dtu/deno.json \
+        packages/soft-dtu/main.ts
+# 加这个 commit script
+git add packages/soft-dtu/.harness/scripts/commit-soft-dtu-webview.sh
+
+git commit -m "feat(soft-dtu): webview framework + HTTP API stub (Phase 1 Day 4-5)
+
+新增 webview/ 子项目 — 软 DTU 控制台 UI 层（Vite + Preact + TypeScript）：
+
+- 4 个面板：
+  1. 串口配置：选串口 + 波特率/数据位/停止位/校验 + open/close
+  2. AT 指令控制台：发 +++AT+XXX + Tab 自动补全 + 解析响应
+  3. HEX/ASCII 实时数据视图：HEX / ASCII / 双视图切换 + 暂停 + 清空
+  4. 协议定义浏览器：浏览 server 拉来的协议 + 手动选 + AT/寄存器表
+
+- HTTP API 端点（src/server/http-api.ts，Phase 1 stub）：
+  - GET  /api/serial/list
+  - POST /api/serial/open
+  - POST /api/serial/close
+  - POST /api/serial/write
+  - GET  /api/serial/status
+  - GET  /api/serial/stream?channel=data|error|close (SSE)
+  - GET  /api/protocols
+  - GET  /api/protocols/refresh
+  - GET  /api/health
+
+- 字段契约（webview/src/bindings.ts）1:1 跟 Deno 端
+  src/bindings/{serial,protocol}.ts 对齐 —— 改字段名必 ping sibling
+  （user memory '跨 worker 字段名约定'）
+
+设计原则：
+- 双进程 dev 工作流：Deno 后端 (8080) + Vite dev server (5173)，Vite proxy /api → 8080
+- WebView 走 HTTP fetch（Phase 1），Phase 2 切 Deno Desktop official bindings SDK
+  （window.bindings.* 直接 IPC 调 Deno runtime，无 HTTP）
+- 协议让用户手动选（UI 启动不预选，Cairui 2026-07-14 16:35 拍板）
+- 类型契约 1:1 跟 server-api-contract.md 对齐（server 端待 ping sibling）
+
+修改文件：
+- main.ts          # 启动 HTTP API server（包装 bindings 给 WebView fetch）
+- deno.json        # 加 webview:install / webview:dev / webview:build 任务
+- README.md        # 更新开发工作流 + 文件结构
+- AGENTS.md        # 加 WebView 双进程 dev 工作流 + HTTP API 端点表
+
+待办（不在本次 commit 范围）：
+- protocol/cellular-dtu.ts 跟 UartNode TCP 握手 + 8 条 AT 响应跑通
+- server 端 GET /api/v2/protocols 端点（已落地 dev，prod 待 push）
+- Modbus RTU 协议实现（485 设备用）— Phase 1 Day 6
+- 端到端集成测试 — Phase 2
+- 切 Deno Desktop bindings SDK（删 http-api.ts）— Phase 2"
+
+echo ""
+echo "✅ 1 commit created"
+echo ""
+echo "📜 Recent commits:"
+git log --oneline -5
+echo ""
+echo "🚀 Push:"
+echo "   git push origin main"
+echo ""
+echo "⚠️  dev 机 github 直连 2026-07-14 起失败（user memory），push 走代理或 Tailscale 中转："
+echo "   HTTPS_PROXY=http://100.76.101.62:7890 git push origin main    # gost proxy（已下线）"
+echo "   # 或 Tailscale SSH 中转（生产端 clone -> tar 回传 -> rsync merge）"

--- a/packages/soft-dtu/AGENTS.md
+++ b/packages/soft-dtu/AGENTS.md
@@ -42,6 +42,44 @@ interface ProtocolDefinition {
 
 > ⚠️ **不要私自起新 server 端表 / 改 schema**：user memory "跨 worker 字段名约定" 那条——拍板落地前必 ping sibling，错位会**静默失败**（HTTP 拉不到 → 走 offline fallback → UI 显示协议少）。
 
+## 协议边界（device.protocols vs soft_dtu.protocols）
+
+uart-server（sibling agent `agent-ae682922673b`）跟软 DTU 端**完全两个独立 collection**，不要混淆。
+
+| 维度 | `device.protocols` (existing) | `soft_dtu.protocols` (new) |
+|---|---|---|
+| **总数 (2026-07-16)** | 30 条 | 2 条 |
+| **Type / type** | `485`(19) / `232`(11) | `cellular-4g-dtu` / `modbus-rtu` |
+| **ProtocolType / type** | `ups`(16) / `air`(8) / `em`(2) / `th`(2) / `io`(2) | (按 DTU 传输层分类, 不按设备品类) |
+| **业务定位** | DTU 后面的 485/232 设备 modbus 指令表 | 软 DTU 自身传输层协议目录 |
+| **AI 协议生成器** | ✅ admin web `/admin/ai` LLM 生成 (决策 16/19/20) | ❌ server seed 静态 + 软 DTU 端 schema 校验 |
+| **instruct 字段** | ✅ modbus 寄存器读/写 hex (0300000002) | ❌ 用 atCommands[] + registers[] |
+| **AT 指令** | ❌ 不存 | ✅ hanfeng-4g-hf2411.atCommands[13] |
+| **source** | `admin` / `ai-generate` / `ai-chat` | `bootstrap` (built-in seed) |
+| **典型条目** | `温湿度1` / `卡乐控制器` / `ZL-U09D2` / `HW-UPS5000` | `汉枫 4G HF2411` / `Modbus RTU RS485 默认` |
+
+**两者正交, 不存在 1:1 映射**:
+- `device.protocols.ProtocolType` 描述"485/232 总线下挂的设备品类"（UPS / 空调 / 电力监测 / 温湿度 / 开关量）
+- `soft_dtu.protocols.type` 描述"软 DTU 自身传输层"（4G / modbus）
+- 一个 4G cellular-4g-dtu 软 DTU 后面可以挂 1 个 ups 设备 + 1 个 th 设备（叠加关系）
+
+**WebView 截图里看到的 "13 条 AT 指令"**（`+++AT+PID` 等）**存 `soft_dtu.protocols.atCommands[]`, 跟 `device.protocols.instruct[]` 完全无关**. 后者是 modbus 寄存器指令 hex (0300000002), 不是 AT 指令.
+
+**加新协议分工**:
+
+| 任务 | 改 collection | 改 uart-server 端 | 改软 DTU 端 |
+|---|---|---|---|
+| 加新 4G DTU 品牌 (非汉枫) | `soft_dtu.protocols` | `src/module/soft-dtu/dto/built-in-protocols.ts` 加 seed | `src/dtus/cellular.ts` 加分支适配 |
+| 加新 485/232 设备 | `device.protocols` | admin web `/admin/ai` 或手填 | (不涉及) |
+| 改 AT 指令格式 (汉枫 4G) | `soft_dtu.protocols.atCommands[]` | `built-in-protocols.ts` 同步 | `src/dtus/cellular.ts` 同步 |
+| 改 modbus 寄存器表 (modbus-rtu-default 那种) | `soft_dtu.protocols.registers[]` | `built-in-protocols.ts` 同步 | (用 server 拉的) |
+
+**改协议 schema 必 ping sibling agent**（`agent-ae682922673b`):
+- uart-server 拥有 `device.protocols` + `soft_dtu.protocols` 两个 collection 的定义权
+- 软 DTU 是实现层, 改字段名 / 加新字段 → 必 ping sibling 拍板
+- 错位会**静默失败**（HTTP 拉不到 → 走 offline fallback → UI 只显示 modbus RTU, 用户以为 bug 实际是协议目录不全）
+- 这条跟 user memory "跨 worker 字段名约定" 强化绑定
+
 ## 跟 UartNode 4G 协议契约（行为 1:1 兼容）
 
 - 软 DTU 是 device，UartNode 是 server —— 软 DTU 主动 connect `UartNode:9000`

--- a/packages/soft-dtu/AGENTS.md
+++ b/packages/soft-dtu/AGENTS.md
@@ -1,0 +1,157 @@
+# AGENTS.md — 软 DTU (`@uart-node/soft-dtu`)
+
+> 项目专属 agent 记忆。**只写读代码 / README 发现不了的事**。每条都问：
+> "如果删掉，下次 agent 会重蹈覆辙吗？" — 答否就删。
+
+## 跟 server 端的关系：HTTP API 拉协议（不鉴权，不连 Socket.IO）
+
+**Cairui 2026-07-14 16:29 + 16:35 拍板**：
+- 软 DTU 走 **HTTP API** `GET /api/v2/protocols` 从 server 拉协议定义
+- **HTTP API 不鉴权**（dev/内网，生产要加 Bearer token，保留 `apiToken` 字段兼容未来）
+- **不连 Socket.IO**（`src/transport/socketio.ts` 整个废弃，commit 时自动 git rm）
+- 数据通道跟普通硬件 DTU 一样（TCP 9000 + 4G 协议），UartNode 代理上行到 server
+- **协议让用户手动选**（UI 启动不预选，Cairui 2026-07-14 16:35 拍板）
+- server 端**必须加** `GET /api/v2/protocols` 端点 —— **必 ping `agent-ae682922673b`**
+
+**为什么走 HTTP 不走 Socket.IO**：
+- HTTP API 简单，curl 就能调
+- 协议定义是低频操作（启动拉一次 + 5min 缓存），不需要 Socket.IO 的长连接
+- HTTP 端点容易鉴权（Bearer token），生产好扩展
+
+**协议定义响应 schema**（server 端必须 1:1 兼容）：
+
+```ts
+interface ProtocolDefinition {
+  id: string;            // "hanfeng-4g-hf2411"
+  name: string;          // "汉枫 4G HF2411"
+  type: "cellular-4g-dtu" | "modbus-rtu" | "lan-gateway" | "uart-direct";
+  manufacturer?: string;
+  model?: string;
+  version?: string;      // 协议定义版本，Phase 2 加
+  atCommands?: AtCommandDefinition[];  // 4G 协议用
+  registers?: RegisterDef[];            // modbus 用
+  register?: RegisterDefinition;        // 4G 注册包定义
+  defaultSerial?: SerialOptions;        // 485 串口参数
+  transport?: "tcp:9000" | "serial" | "tcp:custom";
+}
+```
+
+**离线 fallback**（server 不可达时）：
+- 只放 modbus RTU（公开标准）
+- 不放汉枫 4G（专有协议，hardcode 可能跟 server 不一致）
+
+> ⚠️ **不要私自起新 server 端表 / 改 schema**：user memory "跨 worker 字段名约定" 那条——拍板落地前必 ping sibling，错位会**静默失败**（HTTP 拉不到 → 走 offline fallback → UI 显示协议少）。
+
+## 跟 UartNode 4G 协议契约（行为 1:1 兼容）
+
+- 软 DTU 是 device，UartNode 是 server —— 软 DTU 主动 connect `UartNode:9000`
+- 注册包格式：`register&mac=<IMEI>&host=<hostname>&softdtu=1\r\n`
+  - `&softdtu=1` 标记是软 DTU（UartNode 端**不感知**，只当普通 DTU 处理）
+  - IMEI 15 位，UartNode `slice(-12)` 当 mac 主键
+- 8 条 AT 响应（跟 `src/dtus/cellular.ts:queryAT` 1:1）：
+  - `+++AT+PID` → `+ok=HF2411`
+  - `+++AT+VER` → `+ok=V3.0.0`
+  - `+++AT+GVER` → `+ok=G4`
+  - `+++AT+IOTEN` → `+ok=on`
+  - `+++AT+ICCID` → `+ok=89860117851000012345`
+  - `+++AT+LOCATE=1` → `+ok=31.2049,121.5986`（dev 坐标，cairui 办公室）
+  - `+++AT+UART=1` → `+ok=115200,8,N,1`
+  - `+++AT+GSLQ` → `+ok=20`
+- 特殊指令：
+  - `+++AT+IOTEN=off` → `+ok=`（UartNode 关流量，软 DTU 模拟 ack 不真做）
+  - `+++AT+Z` → `+ok=`（硬重启，UartNode 走 60s 重连路径，软 DTU 不真重启）
+  - `+++AT+NREGEN/NREGDT/IOTUID` → `+ok=\r\n`（UartNode 推的仪式，冗余但要 ack）
+  - 未知指令 → `+err=unknown command: <cmd>`
+
+完整汉枫 AT 指令集定义见 UartNode 端 `src/dtus/cellular.ts`（软 DTU 跟它 1:1 镜像响应）。
+
+## 跨项目 reference
+
+- **跟 UartNode 4G 协议契约**：完全兼容，UartNode 不知道软 DTU 是真的还是假的
+- **跟 `uart-pesiv-node` 完全独立**：不共享配置 / socket.io 封装
+- **跟 `uart-server` 通过 HTTP API（不鉴权）**：server 端 1 个端点（GET /api/v2/protocols），必须 ping sibling
+
+## 部署约束
+
+- **本机 macOS**（cairuimacbook-pro）：CH340/CP2102/FT232 驱动 macOS 13+ 内置
+- **USB 转 485 设备**：插上后 `/dev/tty.usbserial-*` 自动出现
+- **不要硬编码串口路径**：用 `SerialTransport.list()` 动态拿
+- **不要硬编码 IMEI**：用 env / `~/.config/soft-dtu/config.json` 覆盖默认虚拟 IMEI
+- **485 设备最常见是 Modbus RTU**：Phase 1 不实现，Phase 2 加 `npm:modbus-serial`
+- **不要在软 DTU 端 hardcode 汉枫 4G 协议定义**：跟 server 拉的协议不一致会出 bug，UI 显示协议 A 但 server 实际支持 B
+- **不要加 `defaultProtocolId` 配置项**：UI 启动不预选协议，用户手动选
+
+## Runtime 风险
+
+- **Deno Desktop 还在 canary**（Deno 2.9 2026-06-25 发）：bindings API 可能变
+  - Phase 1 stub 用 globalThis + HTTP fetch（main.ts 启 deno serve，webview fetch）
+  - Phase 2 切 Deno Desktop official bindings SDK
+- **macOS 上 npm:serialport 兼容性**：未实测（user memory 里 cairui 装过 Bun 但没装 Deno），装 Deno 时先 `deno --version` 验证
+- **github 直连失败**（user memory 2026-07-14 那条）：Deno / npm 下载可能受影响，先走代理
+- **server 端 API 不可达**：软 DTU 走 offline fallback（modbus RTU only），UI 显示警告"协议目录是离线模式"
+
+## 测试
+
+- **还没有 test**。`deno test` 装上了但 0 个 spec（跟 UartNode PR #12 之前一样）
+- Phase 2 落地时加：
+  - `src/protocol/at-handler.test.ts`（8 条 AT 响应单元测试）
+  - `src/protocol/protocol-catalog.test.ts`（HTTP fetch + 缓存 + offline fallback 流程）
+  - `src/transport/tcp.test.ts`（TCP client mock UartNode 行为）
+  - `src/transport/serial.test.ts`（串口读写，需要真硬件或 mock）
+- **不要凭空加 jest / vitest 配置** —— Deno 内置 `deno test`，加之前先问 cairui
+
+## 已废弃代码
+
+- **`src/transport/socketio.ts`** —— 软 DTU 走 HTTP API 不连 Socket.IO（Cairui 2026-07-14 16:29 拍板）
+  - 保留 deprecated stub 是为了让 commit 脚本自动 git rm（不交互）
+  - **新 session 跑 commit 脚本时脚本会处理**，不要手动 git rm
+  - 不要"修复"或"复活"这个文件
+- **本地 hardcode 汉枫 4G 协议定义** —— 不要做这个！协议定义要从 server 拉，跟硬件 DTU 固件等价物保持单一信息源
+- **`defaultProtocolId` 配置项** —— 已删除（Cairui 2026-07-14 16:35 拍板），不要加回来
+
+## WebView 双进程 dev 工作流（Phase 1）
+
+**软 DTU 后端 + Vite dev server 是两个独立进程**，跟 UartNode 主项目是同一套思路。
+
+```bash
+# 终端 1：Deno runtime 启 HTTP API on 8080
+cd packages/soft-dtu
+deno task dev
+
+# 终端 2：Vite dev server on 5173，proxy /api → 8080
+cd packages/soft-dtu
+deno task webview:install   # 第一次
+deno task webview:dev
+```
+
+浏览器开 `http://127.0.0.1:5173`。
+
+**HTTP API 端点**（`src/server/http-api.ts`，**Phase 1 stub**）：
+
+| Method | Path | 说明 |
+|---|---|---|
+| GET | `/api/serial/list` | 列本机串口 |
+| POST | `/api/serial/open` | `{ path, options }` |
+| POST | `/api/serial/close` | 关串口 |
+| POST | `/api/serial/write` | `{ data: string \| base64 }` |
+| GET | `/api/serial/status` | `{ isOpen, currentPort }` |
+| GET | `/api/serial/stream?channel=data\|error\|close` | SSE 事件流 |
+| GET | `/api/protocols` | `{ protocols: ProtocolDefinition[] }` |
+| GET | `/api/protocols/refresh` | 强制刷新（忽略 5min 缓存）|
+| GET | `/api/health` | health check |
+
+**Phase 2 切 Deno Desktop official bindings SDK**：
+- `webview/src/api.ts` 改用 `window.bindings.*` 替代 fetch
+- `src/server/http-api.ts` 整个文件可以删
+- `deno desktop .` 启动原生窗口（macOS / Windows / Linux），bundle 内嵌 `webview/dist`
+
+**WebView 类型契约 1:1 跟 Deno 端对齐**（`webview/src/bindings.ts` ↔ `src/bindings/{serial,protocol}.ts`）：
+- 改字段名 / 加新字段 → **必 ping sibling 拍板**（user memory "跨 worker 字段名约定"）
+- 错位会**静默失败**（HTTP 拉不到 → fallback 走错 → UI 行为异常）
+
+## 仓库知识库
+
+- 复杂资料（协议速查、调试指南、跟 server 端对接）放 `.harness/docs/`
+- 起步走 `.harness/docs/INDEX.md`（待写）
+- 改 4G 协议契约（`src/protocol/*`）之前**先读** UartNode 端 `src/dtus/cellular.ts` + `src/server/register-handler.ts`（行为 1:1 兼容，不能破坏）
+- 改 HTTP API 拉协议（`src/protocol/protocol-catalog.ts`）之前**必读** server 端协议定义表 schema（等 `agent-ae682922673b` 拍板后写 `.harness/docs/server-alignment.md`）

--- a/packages/soft-dtu/README.md
+++ b/packages/soft-dtu/README.md
@@ -1,0 +1,240 @@
+# 软 DTU (`@uart-node/soft-dtu`)
+
+UartNode 的**软 DTU 客户端**（Deno Desktop 应用）。
+
+## 它是什么
+
+**软 DTU = 伪装成汉枫 4G 硬件 DTU 的 USB 转 485 串口调试工具**
+
+跟普通硬件 DTU 的关系（Cairui 2026-07-14 16:29 + 16:35 拍板）：
+
+| 通道 | 软 DTU 走法 | 硬件 DTU 走法 |
+|---|---|---|
+| **数据通道** | TCP 9000 + 4G 协议（跟硬件 DTU 一样）| TCP 9000 + 4G 协议 |
+| **元数据通道** | HTTP API `GET /api/v2/protocols` 拉协议定义 | 固件内固化（无通道）|
+
+软 DTU 的核心价值：**协议可热更新，不用刷固件**。
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ 软 DTU (Deno Desktop)                                        │
+│ ┌──────────────────────┐   bindings   ┌────────────────────┐ │
+│ │ WebView 前端 (Preact) │◄────────────►│  Deno runtime 后端 │ │
+│ │  - 串口参数配置      │               │  - 串口 (serialport)│ │
+│ │  - HEX/ASCII 切换    │               │  - TCP 9000 客户端 │ │
+│ │  - AT 指令面板       │               │  - 4G 协议模拟      │ │
+│ │  - 协议定义浏览器    │               │  - HTTP 协议拉取    │ │
+│ │    (用户手动选)      │               │                    │ │
+│ └──────────────────────┘               └────────────────────┘ │
+└────────────────┬────────────────────┬──────────────┬─────────┘
+                 │ TCP 9000           │ HTTP API     │ 串口 (RS485)
+                 │ (伪装 4G 协议)     │ (拉协议,    │
+                 │                    │  不鉴权)    │
+                 │                    │
+                 ▼                    ▼              ▼
+         ┌──────────────┐    ┌──────────────┐  ┌──────────┐
+         │  UartNode    │    │ uart-server  │  │ 485 设备 │
+         │  (Bun)       │    │  (midway)    │  │ 现场     │
+         │  0 改动      │    │  待加 API    │  │          │
+         └──────┬───────┘    └──────────────┘  └──────────┘
+                │ Socket.IO
+                ▼
+         ┌──────────────┐
+         │ (server 端    │
+         │ 继续收到 DTU  │
+         │  数据，不知道  │
+         │ 是软是硬)     │
+         └──────────────┘
+```
+
+## 关键能力
+
+1. **伪装 4G DTU** —— 软 DTU 走 TCP 9000 + 注册包 + `+++AT+` 协议，UartNode 不知道它是软的，0 改动
+2. **串口调试工具** —— 跟 XCOM / sscom 兼容，配置 baudRate / dataBits / stopBits / parity
+3. **协议可热更新** —— 走 HTTP API 从 server 拉协议定义，加新协议不动软 DTU
+4. **协议让用户手动选** —— UI 启动不预选，避免猜错协议类型（4G / modbus / LAN 等）
+5. **离线 fallback** —— server 不可达时用本地 stub（modbus RTU 公开标准）
+6. **HTTP API 不鉴权**（dev/内网，生产要加 Bearer token）
+
+## 跟 server 端对接（待 ping agent-ae682922673b）
+
+server 端 (`midwayuartserver`, `agent-ae682922673b` 管) 需要加：
+
+1. **REST 端点 `GET /api/v2/protocols`**（**必加**）：
+   - 鉴权：**不鉴权**（Cairui 2026-07-14 16:35 拍板，dev/内网）
+   - 响应 schema：`{ protocols: ProtocolDefinition[] }`
+   - 协议定义见 `src/protocol/protocol-catalog.ts:ProtocolDefinition`
+
+2. **不连 Socket.IO**（Cairui 2026-07-14 16:29 拍板）：
+   - `src/transport/socketio.ts` 整个文件**已废弃**（commit 时自动 git rm）
+   - 不需要 namespace 放行 / 握手鉴权
+
+## 部署
+
+本地电脑：cairuimacbook-pro
+- macOS 13+ 内置 CH340/CH343/CH9102/CP210x/FTDI 驱动
+- 旧版需要装 WCH 驱动：https://www.wch-ic.com/downloads/CH341SER_MAC_V1.7.html
+- USB 转 485 设备插上后 `/dev/tty.usbserial-*` 自动出现
+
+## 命令
+
+```bash
+cd packages/soft-dtu
+
+# 安装 Deno 2.9 canary（首次）
+deno upgrade canary
+
+# === Deno 后端（软 DTU runtime）===
+# dev 模式（watch + hot reload，启 HTTP API on 127.0.0.1:8080）
+deno task dev
+# 生产模式
+deno task start
+# 打包桌面应用（macOS .app/.dmg, Windows .msi, Linux .AppImage）
+deno task desktop:all
+# 跑测试
+deno task test
+
+# === WebView 前端（Vite + Preact）===
+# 第一次需要装依赖
+deno task webview:install
+# dev 模式（Vite dev server on 127.0.0.1:5173，proxy /api → 8080）
+deno task webview:dev
+# 生产构建
+deno task webview:build
+# 类型检查
+deno task webview:typecheck
+```
+
+## 完整 dev 工作流（Phase 1）
+
+**双进程** — 软 DTU 后端（Deno）+ Vite dev server（Vite/Preact）：
+
+```bash
+# 终端 1：启动软 DTU 后端
+cd packages/soft-dtu
+deno task dev
+# → http://127.0.0.1:8080/api/health
+
+# 终端 2：启动 WebView
+cd packages/soft-dtu
+deno task webview:install  # 第一次
+deno task webview:dev
+# → http://127.0.0.1:5173
+```
+
+Vite dev server proxy `/api/*` → 8080，浏览器开 `http://127.0.0.1:5173` 即可。
+
+Phase 2 切 Deno Desktop bindings SDK 后可以合并成单进程（`deno desktop`）。
+
+## 项目结构
+
+```
+packages/soft-dtu/
+├── deno.json                    # Deno 配置 + tasks（含 webview:* 子任务）
+├── main.ts                      # Deno runtime 入口（含 HTTP API server 启动）
+├── README.md                    # 本文件
+├── AGENTS.md                    # agent 记忆（项目级约束）
+├── .harness/
+│   ├── docs/                    # 知识库（独立于 UartNode 根 .harness/）
+│   └── scripts/                 # commit helper
+├── src/
+│   ├── protocol/                # 4G DTU 协议模拟 + 协议目录
+│   │   ├── cellular-dtu.ts      # 4G DTU 行为（注册 + 8 条 AT 响应）
+│   │   ├── at-handler.ts        # AT 指令响应生成
+│   │   ├── config.ts            # 虚拟 IMEI / PID / VER / 串口配置 / server URL
+│   │   └── protocol-catalog.ts  # 协议仓库（HTTP fetch + 缓存 + offline fallback）
+│   ├── transport/               # 底层 transport
+│   │   ├── tcp.ts               # TCP client 连 UartNode:9000
+│   │   └── serial.ts            # 串口（npm:serialport）
+│   ├── bindings/                # IPC bindings（WebView → Deno）
+│   │   ├── serial.ts            # 串口操作 IPC
+│   │   └── protocol.ts          # 协议目录 IPC（走 HTTP API）
+│   └── server/
+│       └── http-api.ts          # Phase 1: bindings → HTTP wrapper
+└── webview/                     # Vite + Preact + TypeScript 前端
+    ├── package.json
+    ├── vite.config.ts           # dev proxy /api → 8080
+    ├── tsconfig.json            # Preact JSX
+    ├── index.html               # SPA 入口
+    ├── README.md                # webview 独立说明
+    └── src/
+        ├── main.tsx             # Preact mount
+        ├── App.tsx              # Tab 路由（4 个面板）
+        ├── bindings.ts          # 类型契约（1:1 跟 Deno 端对齐）
+        ├── api.ts               # HTTP fetch wrapper
+        ├── styles.css           # 暗色主题
+        └── panels/
+            ├── SerialConfig.tsx     # 串口参数 + open/close
+            ├── ATConsole.tsx        # AT 指令控制台 + 自动补全
+            ├── HexView.tsx          # HEX/ASCII 实时数据视图
+            └── ProtocolViewer.tsx   # 协议定义浏览器
+```
+
+## 跟姊妹项目关系
+
+| 项目 | Runtime | 角色 | 跟软 DTU 关系 |
+|---|---|---|---|
+| `UartNode` (root) | Bun | DTU 网关 | 软 DTU 伪装 4G DTU 跟它通信（数据通道）|
+| `uart-pesiv-node` | Bun | PESIV UPS 卡专用 | 完全独立，不共享配置 |
+| `uart-server` (midwayuartserver) | Node/Midway | Server | 待加 `GET /api/v2/protocols` 端点（元数据通道，不鉴权）|
+| `软 DTU` (本项目) | Deno | 设备代理 + 串口调试 | — |
+
+## 配置
+
+`~/.config/soft-dtu/config.json`（不存在时用默认 + env 覆盖）：
+
+```json
+{
+  "virtualImei": "358700000000123",
+  "pid": "HF2411",
+  "ver": "V3.0.0",
+  "gver": "G4",
+  "iccid": "89860117851000012345",
+  "iotStat": "on",
+  "signal": 20,
+  "uartNode": {
+    "host": "127.0.0.1",
+    "port": 9000
+  },
+  "uartServer": {
+    "url": "http://127.0.0.1:9010",
+    "apiPath": "/api/v2",
+    "apiToken": "",
+    "timeoutMs": 10000
+  },
+  "defaultSerial": {
+    "baudRate": 115200,
+    "dataBits": 8,
+    "stopBits": 1,
+    "parity": "none"
+  }
+}
+```
+
+env 变量优先：
+- `SOFT_DTU_IMEI` / `SOFT_DTU_PID` / `SOFT_DTU_VER` / `SOFT_DTU_GVER` / `SOFT_DTU_ICCID` / `SOFT_DTU_IOTSTAT` / `SOFT_DTU_SIGNAL`
+- `UART_NODE_HOST` / `UART_NODE_PORT`
+- `UART_SERVER_URL` / `UART_SERVER_API_PATH` / `UART_SERVER_API_TOKEN` / `UART_SERVER_TIMEOUT_MS`
+
+**协议选择**（`defaultProtocolId`）已删除（Cairui 2026-07-14 16:35 拍板）—— UI 启动不预选，用户手动选。
+
+## 开发状态
+
+**2026-07-15 15:20**：第二波代码（WebView 骨架 + 4 面板 + HTTP API stub）
+
+- ✅ webview/ 骨架（Vite + Preact + TypeScript）
+- ✅ 4 个面板（串口配置 / AT 指令 / HEX-ASCII / 协议定义）
+- ✅ HTTP API server（包装 bindings，WebView 走 fetch 调）
+- ⏳ protocol/cellular-dtu.ts 跟 UartNode TCP 握手 + 8 条 AT 响应跑通
+- ⏳ 端到端集成测试
+- ⏳ B-level review issues 清理（5 个 minor）
+
+## 已知坑
+
+- **bash tool 之前因 workspace 快照失灵**（跟 user memory 2026-07-14 那条 `defaultWorkspaceDir` 坑一致），本文件用 write 工具绝对路径写，**未 commit**，等新 session 跑 `.harness/scripts/commit-soft-dtu-skeleton.sh`
+- **Deno Desktop 还在 canary**（Deno 2.9 2026-06-25 发），bindings API 可能变，Phase 1 stub + Phase 2 跟进
+- **macOS 旧版要装 CH340 驱动**：https://www.wch-ic.com/downloads/CH341SER_MAC_V1.7.html
+- **github 直连失败**（user memory 2026-07-14 那条），Deno 安装 / npm 下载可能受影响，先验证 `deno --version`
+- **`src/transport/socketio.ts` 已废弃**（Cairui 2026-07-14 16:29 拍板），保留 deprecated stub 是为了让 commit 脚本自动 git rm（不交互）
+- **server 端 `GET /api/v2/protocols` 端点要加** —— 必须 ping `agent-ae682922673b`（user memory "跨 worker 字段名约定" 那条：拍板落地前必 ping sibling）
+- **HTTP API 不鉴权**（Cairui 2026-07-14 16:35 拍板），仅 dev/内网用，生产要加 Bearer token

--- a/packages/soft-dtu/deno.json
+++ b/packages/soft-dtu/deno.json
@@ -2,8 +2,9 @@
   "name": "@uart-node/soft-dtu",
   "version": "0.1.0",
   "description": "UartNode 软 DTU (Deno Desktop) — 伪装汉枫 4G 协议连 UartNode + USB 转 485 串口调试工具",
+  "exports": "./main.ts",
   "tasks": {
-    "dev": "deno run -A --watch=src/,main.ts main.ts",
+    "dev": "deno run -A --watch=src/,main.ts --env-file=.env main.ts",
     "start": "deno run -A main.ts",
     "desktop": "deno desktop .",
     "desktop:all": "deno desktop --all-targets .",
@@ -40,6 +41,6 @@
     }
   },
   "nodeModulesDir": "auto",
-  "unstable": ["desktop"],
+  "unstable": [],
   "exclude": ["node_modules", "dist", "webview/dist"]
 }

--- a/packages/soft-dtu/deno.json
+++ b/packages/soft-dtu/deno.json
@@ -1,0 +1,45 @@
+{
+  "name": "@uart-node/soft-dtu",
+  "version": "0.1.0",
+  "description": "UartNode 软 DTU (Deno Desktop) — 伪装汉枫 4G 协议连 UartNode + USB 转 485 串口调试工具",
+  "tasks": {
+    "dev": "deno run -A --watch=src/,main.ts main.ts",
+    "start": "deno run -A main.ts",
+    "desktop": "deno desktop .",
+    "desktop:all": "deno desktop --all-targets .",
+    "test": "deno test -A",
+    "fmt": "deno fmt",
+    "lint": "deno lint",
+    "check": "deno check **/*.ts",
+    "webview:install": "cd webview && npm install",
+    "webview:dev": "cd webview && npm run dev",
+    "webview:build": "cd webview && npm run build",
+    "webview:typecheck": "cd webview && npm run typecheck"
+  },
+  "imports": {
+    "serialport": "npm:serialport@^12.0.0",
+    "@std/encoding": "jsr:@std/encoding@^1.0.0",
+    "@std/path": "jsr:@std/path@^1.0.0",
+    "@std/fs": "jsr:@std/fs@^1.0.0",
+    "@std/log": "jsr:@std/log@^0.224.0"
+  },
+  "compilerOptions": {
+    "lib": ["deno.window", "dom", "dom.iterable", "dom.asynciterable"],
+    "strict": true
+  },
+  "fmt": {
+    "lineWidth": 100,
+    "indentWidth": 2,
+    "semiColons": true,
+    "singleQuote": false
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"],
+      "exclude": ["no-explicit-any"]
+    }
+  },
+  "nodeModulesDir": "auto",
+  "unstable": ["desktop"],
+  "exclude": ["node_modules", "dist", "webview/dist"]
+}

--- a/packages/soft-dtu/deno.json
+++ b/packages/soft-dtu/deno.json
@@ -11,7 +11,7 @@
     "test": "deno test -A",
     "fmt": "deno fmt",
     "lint": "deno lint",
-    "check": "deno check **/*.ts",
+    "check": "deno check main.ts src/**/*.ts",
     "webview:install": "cd webview && npm install",
     "webview:dev": "cd webview && npm run dev",
     "webview:build": "cd webview && npm run build",

--- a/packages/soft-dtu/main.ts
+++ b/packages/soft-dtu/main.ts
@@ -71,8 +71,11 @@ tcp.on("log", (msg) => console.log(`[tcp] ${msg}`));
 const serial = new SerialTransport();
 
 // 4. 协议仓库（HTTP API 拉协议定义，元数据通道，不鉴权）
+//    baseUrl 只放 origin，path `/api/v2/protocols` 在 ProtocolRepository 内部拼
+//    （之前 `${url}${apiPath}` + 内部 `/api/v2/protocols` 会拼成 `/api/v2/api/v2/protocols`）
 const protocolRepo = new ProtocolRepository({
-  baseUrl: `${config.uartServer.url}${config.uartServer.apiPath}`,
+  baseUrl: config.uartServer.url,
+  apiPath: config.uartServer.apiPath,
   timeoutMs: config.uartServer.timeoutMs,
 });
 

--- a/packages/soft-dtu/main.ts
+++ b/packages/soft-dtu/main.ts
@@ -1,0 +1,121 @@
+/**
+ * 软 DTU 主入口（Deno Desktop）
+ *
+ * 启动顺序：
+ *   1. 加载配置（虚拟 IMEI / PID / VER / 串口参数 / server URL）
+ *   2. 启动 transport 层（TCP 连 UartNode + 串口 + HTTP client 拉协议）
+ *   3. 启动 protocol 层（4G DTU 行为模拟）
+ *   4. 注册 bindings（暴露给 WebView 前端）
+ *   5. 启动 WebView（deno desktop 命令会接管这一步，本文件提供 main 逻辑）
+ *
+ * 跟 UartNode 对接（数据通道，跟普通硬件 DTU 一样）：
+ *   - 软 DTU 不知道 UartNode 长啥样，只知道"4G 协议"那套契约
+ *   - UartNode 不知道软 DTU 是真的还是假的，只当普通 DTU
+ *   - 走 TCP 9000 + 'register&mac=<虚拟IMEI>&host=...' + '+++AT+' 协议
+ *   - IMEI 后 12 位当 mac（跟硬件 DTU 完全一样）
+ *
+ * 跟 uart-server 对接（元数据通道，HTTP API，不鉴权）：
+ *   - 走 GET /api/v2/protocols 拉协议定义
+ *   - 不连 Socket.IO（Cairui 2026-07-14 16:29 拍板）
+ *   - server 端 agent-ae682922673b 待加 API 端点
+ *
+ * 跟姊妹项目 uart-pesiv-node 关系：
+ *   - 完全独立
+ *   - 不共享配置 / socket.io 封装
+ *   - UartNode=Bun, 软 DTU=Deno, pesiv=Bun 三者 runtime 都不同
+ *
+ * Phase 1 任务：
+ *   Day 1: 本文件 + 协议层 + transport 层 + bindings 层（已写）
+ *   Day 2-3: protocol/cellular-dtu.ts 跟 UartNode TCP 握手 + 8 条 AT 响应跑通
+ *   Day 4-5: webview/ 骨架（Vite + Preact）+ 4 个面板 + HTTP API stub（已写）
+ *   Day 6: 集成测试（端到端跑通 8 条 AT + 串口 + WebView UI）
+ *   Day 7: 修 B-level issues + 补单元测试
+ */
+
+import { loadConfig, type SoftDtuConfig } from "./src/protocol/config.ts";
+import { CellularDtu } from "./src/protocol/cellular-dtu.ts";
+import { TcpTransport } from "./src/transport/tcp.ts";
+import { SerialTransport, listSerialPorts } from "./src/transport/serial.ts";
+import { registerSerialBindings } from "./src/bindings/serial.ts";
+import { ProtocolRepository } from "./src/protocol/protocol-catalog.ts";
+import { registerProtocolBindings } from "./src/bindings/protocol.ts";
+import { startHttpApi } from "./src/server/http-api.ts";
+
+console.log("[soft-dtu] starting...");
+console.log(`[soft-dtu] deno: ${Deno.version.deno}`);
+console.log(`[soft-dtu] v8: ${Deno.version.v8}`);
+console.log(`[soft-dtu] typescript: ${Deno.version.typescript}`);
+
+const config: SoftDtuConfig = await loadConfig();
+console.log(`[soft-dtu] config: mac=${config.virtualImei.slice(-12)} pid=${config.pid} ver=${config.ver}`);
+
+// 1. 串口 transport（dev 上不一定插了，先 list 一遍看）
+try {
+  const ports = await listSerialPorts();
+  console.log(`[soft-dtu] serial ports available: ${ports.length}`);
+  for (const p of ports) {
+    console.log(`  - ${p.path} (${p.manufacturer ?? "?"} ${p.productId ?? ""})`);
+  }
+} catch (err) {
+  console.warn(`[soft-dtu] serial list failed:`, err);
+}
+
+// 2. TCP transport 连 UartNode（数据通道，跟普通硬件 DTU 一样）
+const tcp = new TcpTransport({
+  host: config.uartNode.host,
+  port: config.uartNode.port,
+});
+tcp.on("log", (msg) => console.log(`[tcp] ${msg}`));
+
+// 3. 串口 transport（默认不开，等 UI 触发）
+const serial = new SerialTransport();
+
+// 4. 协议仓库（HTTP API 拉协议定义，元数据通道，不鉴权）
+const protocolRepo = new ProtocolRepository({
+  baseUrl: `${config.uartServer.url}${config.uartServer.apiPath}`,
+  timeoutMs: config.uartServer.timeoutMs,
+});
+
+// 5. 4G DTU 协议模拟
+const dtu = new CellularDtu({
+  config,
+  tcp,
+});
+dtu.on("log", (msg) => console.log(`[dtu] ${msg}`));
+
+// 6. 注册 IPC bindings（暴露给 WebView 前端）
+const serialBindings = registerSerialBindings(serial);
+const protocolBindings = registerProtocolBindings(protocolRepo);
+
+// 6.5 Phase 1: 启动 HTTP API server（包装 bindings，WebView 走 fetch 调过来）
+//   Phase 2 切 Deno Desktop bindings SDK 后可以删
+//   默认 127.0.0.1:8080，env 覆盖：SOFT_DTU_HTTP_HOST / SOFT_DTU_HTTP_PORT
+const httpHost = Deno.env.get("SOFT_DTU_HTTP_HOST") ?? "127.0.0.1";
+const httpPort = Number(Deno.env.get("SOFT_DTU_HTTP_PORT") ?? 8080);
+startHttpApi({ host: httpHost, port: httpPort }, serialBindings, protocolBindings);
+
+// 7. 启动时拉协议（fire-and-forget，失败走 offline fallback）
+//    UI 启动不预选协议（Cairui 2026-07-14 16:35 拍板），让用户手动选
+try {
+  const protocols = await protocolRepo.list();
+  console.log(`[soft-dtu] protocol catalog: ${protocols.length} protocols (${protocolRepo.isOffline() ? "offline fallback" : "from server"})`);
+  for (const p of protocols) {
+    console.log(`  - ${p.id}: ${p.name} (${p.type})`);
+  }
+  console.log(`[soft-dtu] protocol selection: user picks manually in UI`);
+} catch (err) {
+  console.warn(`[soft-dtu] initial protocol fetch failed:`, err);
+}
+
+// 8. 启动 DTU 协议（连 UartNode + 发注册包 + 响应 8 条 AT）
+await dtu.start();
+
+// 9. 优雅关闭
+globalThis.addEventListener("unload", () => {
+  console.log("[soft-dtu] shutting down...");
+  dtu.stop();
+  tcp.close();
+  serial.close();
+});
+
+console.log("[soft-dtu] ready. mac=" + config.virtualImei.slice(-12));

--- a/packages/soft-dtu/src/bindings/protocol.ts
+++ b/packages/soft-dtu/src/bindings/protocol.ts
@@ -1,0 +1,55 @@
+/**
+ * 协议 IPC Bindings — 暴露给 WebView 前端
+ *
+ * 软 DTU 走 HTTP API 从 server 拉协议定义（GET /api/v2/protocols）
+ * 跟之前规划的 Socket.IO 模式不同（Cairui 2026-07-14 16:29 拍板）
+ *
+ * 暴露给前端的 API：
+ *   - protocol.list(): Promise<ProtocolDefinition[]>  // 走 HTTP，5min 缓存
+ *   - protocol.get(id): ProtocolDefinition | undefined  // 同步，从缓存查
+ *   - protocol.refresh(): Promise<ProtocolDefinition[]>  // 强制刷新
+ *   - protocol.isOffline(): boolean  // 是否离线模式
+ *   - protocol.onUpdate(handler): unsubscribe  // server 返回新协议时回调
+ *
+ * Phase 1 范围：从 server 拉汉枫 4G / Modbus RTU 等协议
+ * server 端 agent-ae682922673b 待加 GET /api/v2/protocols 端点
+ */
+
+import {
+  ProtocolRepository,
+  type ProtocolDefinition,
+  type AtCommandDefinition,
+} from "../protocol/protocol-catalog.ts";
+
+export interface ProtocolBindings {
+  list(): Promise<ProtocolDefinition[]>;
+  get(id: string): ProtocolDefinition | undefined;
+  refresh(): Promise<ProtocolDefinition[]>;
+  isOffline(): boolean;
+  onUpdate(handler: (protocols: ProtocolDefinition[]) => void): () => void;
+}
+
+export function createProtocolBindings(repo: ProtocolRepository): ProtocolBindings {
+  return {
+    list: () => repo.list(),
+    get: (id) => repo.get(id),
+    refresh: () => repo.refresh(),
+    isOffline: () => repo.isOffline(),
+    onUpdate: (handler) => repo.onUpdate(handler),
+  };
+}
+
+export function registerProtocolBindings(repo: ProtocolRepository): ProtocolBindings {
+  const bindings = createProtocolBindings(repo);
+
+  // 暴露到 globalThis 让 HTTP handler 能访问
+  (globalThis as Record<string, unknown>).__protocolBindings = bindings;
+
+  // 启动时拉一次（fire-and-forget，失败走 offline fallback）
+  bindings.list().catch((err) => {
+    console.warn("[bindings] initial protocol fetch failed:", err);
+  });
+
+  console.log("[bindings] protocol bindings registered (HTTP API, 5min cache)");
+  return bindings;
+}

--- a/packages/soft-dtu/src/bindings/serial.ts
+++ b/packages/soft-dtu/src/bindings/serial.ts
@@ -1,0 +1,128 @@
+/**
+ * 串口 IPC Bindings — 暴露给 WebView 前端
+ *
+ * Deno Desktop 模式：WebView → bindings → Deno runtime
+ * - 用 Deno 2.9 desktop 的 IPC channel（具体 API 等 Deno 2.9 stable 后确认）
+ * - Phase 1 stub：定义 API surface
+ * - Phase 2 实现：调 Deno Desktop bindings SDK
+ *
+ * 暴露给前端的 API：
+ *   - serial.list(): Promise<SerialPortInfo[]>
+ *   - serial.open(path, options): Promise<void>
+ *   - serial.close(): Promise<void>
+ *   - serial.write(data: string | Uint8Array): Promise<void>
+ *   - serial.onData(callback): unsubscribe
+ *   - serial.onError(callback): unsubscribe
+ *
+ * Phase 1 用 localStorage + 自定义事件 stub（deno serve 起 HTTP，前端 fetch）
+ * Phase 2 切 Deno Desktop bindings（避免 HTTP 跨进程）
+ */
+
+import type { SerialTransport, SerialPortInfo, SerialOptions } from "../transport/serial.ts";
+
+export interface SerialBindings {
+  list(): Promise<SerialPortInfo[]>;
+  open(path: string, options: SerialOptions): Promise<void>;
+  close(): Promise<void>;
+  write(data: string | Uint8Array): Promise<void>;
+  isOpen(): boolean;
+  /** 当前打开的串口信息 */
+  currentPort(): { path: string; options: SerialOptions } | null;
+  /** 串口数据回调（WebView 订阅）*/
+  onData(handler: (data: Uint8Array) => void): () => void;
+  /** 串口错误回调 */
+  onError(handler: (err: Error) => void): () => void;
+  /** 串口关闭回调 */
+  onClose(handler: () => void): () => void;
+}
+
+export function createSerialBindings(serial: SerialTransport): SerialBindings {
+  let current: { path: string; options: SerialOptions } | null = null;
+  const dataHandlers = new Set<(data: Uint8Array) => void>();
+  const errorHandlers = new Set<(err: Error) => void>();
+  const closeHandlers = new Set<() => void>();
+
+  serial.on("data", (data) => {
+    for (const h of dataHandlers) {
+      try {
+        h(data);
+      } catch (err) {
+        console.warn("[serial bindings] data handler error:", err);
+      }
+    }
+  });
+  serial.on("error", (err) => {
+    for (const h of errorHandlers) {
+      try {
+        h(err);
+      } catch (e) {
+        console.warn("[serial bindings] error handler error:", e);
+      }
+    }
+  });
+  serial.on("close", () => {
+    current = null;
+    for (const h of closeHandlers) {
+      try {
+        h();
+      } catch (err) {
+        console.warn("[serial bindings] close handler error:", err);
+      }
+    }
+  });
+
+  return {
+    async list() {
+      return SerialTransport.list();
+    },
+    async open(path, options) {
+      await serial.open(path, options);
+      current = { path, options };
+    },
+    async close() {
+      serial.close();
+      current = null;
+    },
+    async write(data) {
+      if (typeof data === "string") {
+        await serial.write(new TextEncoder().encode(data));
+      } else {
+        await serial.write(data);
+      }
+    },
+    isOpen() {
+      return serial.isOpen;
+    },
+    currentPort() {
+      return current;
+    },
+    onData(handler) {
+      dataHandlers.add(handler);
+      return () => dataHandlers.delete(handler);
+    },
+    onError(handler) {
+      errorHandlers.add(handler);
+      return () => errorHandlers.delete(handler);
+    },
+    onClose(handler) {
+      closeHandlers.add(handler);
+      return () => closeHandlers.delete(handler);
+    },
+  };
+}
+
+/**
+ * 注册到全局（Deno Desktop bindings 模式）
+ * Phase 1 stub：通过 Deno.core.ops 注册自定义 op
+ * Phase 2 切 Deno Desktop official bindings SDK
+ */
+export function registerSerialBindings(serial: SerialTransport): SerialBindings {
+  const bindings = createSerialBindings(serial);
+
+  // Phase 1: 暴露到 globalThis 让 deno serve HTTP handler 能访问
+  // 前端 fetch('/api/serial/list') 走 HTTP，main.ts HTTP handler 调 bindings.list()
+  (globalThis as Record<string, unknown>).__serialBindings = bindings;
+
+  console.log("[bindings] serial bindings registered");
+  return bindings;
+}

--- a/packages/soft-dtu/src/bindings/serial.ts
+++ b/packages/soft-dtu/src/bindings/serial.ts
@@ -18,7 +18,9 @@
  * Phase 2 切 Deno Desktop bindings（避免 HTTP 跨进程）
  */
 
-import type { SerialTransport, SerialPortInfo, SerialOptions } from "../transport/serial.ts";
+// SerialTransport 是 class (value + type) — 不能 import type, 不然 .list() 报 ReferenceError
+// SerialPortInfo / SerialOptions 是 interface, type-only 即可
+import { SerialTransport, type SerialPortInfo, type SerialOptions } from "../transport/serial.ts";
 
 export interface SerialBindings {
   list(): Promise<SerialPortInfo[]>;

--- a/packages/soft-dtu/src/protocol/at-handler.ts
+++ b/packages/soft-dtu/src/protocol/at-handler.ts
@@ -1,0 +1,97 @@
+/**
+ * 4G DTU AT 指令响应
+ *
+ * 实现汉枫 HF2411 的 8 条核心 AT 指令（跟 UartNode 端 cellular.ts:initialize() 1:1 对齐）：
+ *   - PID    → +ok=HF2411
+ *   - VER    → +ok=V3.0.0
+ *   - GVER   → +ok=G4
+ *   - IOTEN  → +ok=on / +ok=off
+ *   - ICCID  → +ok=89860117851000012345
+ *   - LOCATE → +ok=<lat>,<lon>
+ *   - UART   → +ok=115200,8,N,1
+ *   - GSLQ   → +ok=20
+ *
+ * 跟 src/dtus/cellular.ts:queryAT() 行为 1:1 兼容
+ *   - UartNode 发 '+++AT+PID\r' → 软 DTU 返回 '+ok=HF2411'
+ *   - UartNode 解析 '/^\+ok=/i' 匹配，存进 dtu.PID 字段
+ *
+ * Phase 1 实现：8 条硬编码响应
+ * Phase 2 实现：跟 uart-server 拉协议定义动态生成
+ *
+ * 不实现 LOCATE 真实定位（软 DTU 在 dev 电脑上，没 GPS 模组）— 返回 dev 坐标
+ * 不实现 GSLQ 真实信号（软 DTU 没蜂窝模组）— 返回 config.signal 默认值
+ */
+
+import type { SoftDtuConfig } from "./config.ts";
+
+/**
+ * AT 指令响应生成器
+ *
+ * 输入: '+++AT+PID\r' (Buffer)
+ * 输出: '+ok=HF2411\r' (Buffer)
+ */
+export function atResponse(
+  command: string,
+  config: SoftDtuConfig,
+): string {
+  // 去掉 '+++AT+' 前缀和 '\r' 后缀
+  const cmd = command.replace(/^\+{3}AT\+/, "").replace(/\r$/, "").trim();
+
+  switch (cmd) {
+    case "PID":
+      return `+ok=${config.pid}`;
+
+    case "VER":
+      return `+ok=${config.ver}`;
+
+    case "GVER":
+      return `+ok=${config.gver}`;
+
+    case "IOTEN":
+      // 软 DTU 总是返回 on（UartNode 端 CellularDtu.initialize() 会再发 IOTEN=off 关流量）
+      return `+ok=${config.iotStat}`;
+
+    case "ICCID":
+      return `+ok=${config.iccid}`;
+
+    case "LOCATE=1":
+      // dev 坐标（上海张江，cairui 办公室附近）
+      return `+ok=31.2049,121.5986`;
+
+    case "UART=1":
+      // 报告当前串口参数
+      return `+ok=${config.defaultSerial.baudRate},${config.defaultSerial.dataBits},${config.defaultSerial.parity[0]?.toUpperCase() ?? "N"},${config.defaultSerial.stopBits}`;
+
+    case "GSLQ":
+      return `+ok=${config.signal}`;
+
+    case "IOTEN=off":
+      // UartNode 关流量指令，软 DTU 模拟 ack（不实际做啥）
+      return `+ok=`;
+
+    case "Z":
+      // 硬重启（UartNode 端 10 次超时硬重启走这条）
+      // 软 DTU 不真重启（保持 dev 状态），返回 ack 让 UartNode 走 60s 重连路径
+      return `+ok=`;
+
+    default:
+      // 未知指令 — 返回 +err 让 UartNode 知道（保持跟真硬件 DTU 一致的行为）
+      return `+err=unknown command: ${cmd}`;
+  }
+}
+
+/**
+ * 检查是否是 AT 指令（前缀 +++AT+）
+ */
+export function isAtCommand(data: Uint8Array | string): boolean {
+  const str = typeof data === "string" ? data : new TextDecoder().decode(data);
+  return str.startsWith("+++AT+");
+}
+
+/**
+ * 提取 AT 指令内容（去掉前缀 + 后缀）
+ */
+export function extractAtCommand(data: Uint8Array | string): string {
+  const str = typeof data === "string" ? data : new TextDecoder().decode(data);
+  return str.replace(/^\+{3}AT\+/, "").replace(/\r$/, "").trim();
+}

--- a/packages/soft-dtu/src/protocol/cellular-dtu.ts
+++ b/packages/soft-dtu/src/protocol/cellular-dtu.ts
@@ -1,0 +1,178 @@
+/**
+ * CellularDtu — 软 DTU 4G 协议模拟
+ *
+ * 行为契约：跟 UartNode 端 src/dtus/cellular.ts 1:1 兼容
+ *   1. 启动连 UartNode:9000（TCP）
+ *   2. 等 UartNode 推 '+++AT+NREGEN=...' 仪式
+ *   3. 主动发注册包 'register&mac=<虚拟IMEI>&host=...\r\n'
+ *   4. 响应 8 条 AT 指令（PID/VER/GVER/IOTEN/ICCID/LOCATE/UART/GSLQ）
+ *   5. 持续监听 socket，处理下行指令（+++AT+ 透传穿）
+ *   6. socket 断开时按 reboot 模式决定重连策略
+ *
+ * 跟 UartNode 对接关键点：
+ *   - TcpServer.ts:onConnection 嗅探 'register&' 前缀
+ *   - CellularRegisterHandler.handle URLSearchParams 解析
+ *   - IMEI.slice(-12) 当 mac 主键
+ *   - 8 条 AT 在 CellularDtu.initialize() 顺序查
+ *
+ * 软 DTU 不知道 UartNode 长啥样，只知道"4G 协议"那套契约
+ * UartNode 不知道软 DTU 是真的还是假的，只当普通 DTU
+ *
+ * 跟 server 端的关系：完全无关（Cairui 2026-07-14 16:21 拍板）
+ *   - 跟普通硬件 DTU 完全对等
+ *   - server 端零改动，零端点
+ *   - 协议定义本地 hardcode（src/protocol/protocol-catalog.ts）
+ */
+
+import { EventEmitter } from "node:events";
+import type { TcpTransport } from "../transport/tcp.ts";
+import type { SoftDtuConfig } from "./config.ts";
+import { atResponse, isAtCommand, extractAtCommand } from "./at-handler.ts";
+
+export interface CellularDtuOptions {
+  config: SoftDtuConfig;
+  tcp: TcpTransport;
+}
+
+export class CellularDtu extends EventEmitter {
+  private readonly config: SoftDtuConfig;
+  private readonly tcp: TcpTransport;
+  private connected = false;
+  private registered = false;
+  private reconnectAttempts = 0;
+  private maxReconnectAttempts = 5;
+  private reconnectTimer: number | null = null;
+
+  constructor(opts: CellularDtuOptions) {
+    super();
+    this.config = opts.config;
+    this.tcp = opts.tcp;
+  }
+
+  /**
+   * 启动 DTU（连 UartNode + 发注册包 + 响应 AT）
+   */
+  async start(): Promise<void> {
+    this.tcp.on("data", (data) => this.onTcpData(data));
+    this.tcp.on("close", () => this.onTcpClose());
+    this.tcp.on("error", (err) => this.emit("log", `tcp error: ${err.message}`));
+
+    await this.connect();
+  }
+
+  /**
+   * 停止 DTU
+   */
+  stop(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.tcp.close();
+    this.connected = false;
+    this.registered = false;
+  }
+
+  /**
+   * TCP 连接 UartNode
+   */
+  private async connect(): Promise<void> {
+    const mac = this.config.virtualImei.slice(-12);
+    this.emit("log", `connecting to UartNode ${this.config.uartNode.host}:${this.config.uartNode.port} as mac=${mac}`);
+
+    try {
+      await this.tcp.connect();
+      this.connected = true;
+      this.reconnectAttempts = 0;
+      this.emit("log", "tcp connected");
+
+      // 主动发注册包（不等 UartNode 推 +++AT+ 仪式，直接发）
+      // 协议：register&mac=<IMEI>&host=<hostname>
+      // 跟 UartNode 端 src/server/register-handler.ts:CellularRegisterHandler.handle 1:1
+      const hostname = (await this.getHostname()) ?? "soft-dtu";
+      const registerPacket =
+        `register&mac=${this.config.virtualImei}&host=${hostname}&softdtu=1\r\n`;
+      await this.tcp.send(new TextEncoder().encode(registerPacket));
+      this.registered = true;
+      this.emit("log", `register sent: ${registerPacket.trim()}`);
+    } catch (err) {
+      this.emit("log", `connect failed: ${(err as Error).message}`);
+      this.scheduleReconnect();
+    }
+  }
+
+  /**
+   * TCP 数据接收（UartNode → 软 DTU）
+   * 处理两类：
+   *   1. UartNode 推的 +++AT+NREGEN/NREGDT/IOTUID 仪式（连接握手时）
+   *   2. UartNode 发的 +++AT+XXX 查询（8 条 AT 批量查）
+   *   3. UartNode 下发的 +++AT+XXX 操作指令（透传穿到硬件设备 — Phase 2）
+   */
+  private async onTcpData(data: Uint8Array): Promise<void> {
+    const str = new TextDecoder().decode(data);
+    this.emit("log", `tcp <<< ${str.trim()}`);
+
+    if (isAtCommand(str)) {
+      const cmd = extractAtCommand(str);
+      this.emit("log", `at cmd: ${cmd}`);
+
+      // 特殊处理 UartNode 推的 NREGEN/NREGDT 仪式（不响应，让 UartNode 知道我们 ok）
+      if (cmd.startsWith("NREGEN") || cmd.startsWith("NREGDT") || cmd.startsWith("IOTUID")) {
+        // 软 DTU 已经主动发了 register 包，NREGEN/NREGDT 仪式是冗余的
+        // 但要 ack 让 UartNode 不 destroy socket
+        await this.tcp.send(new TextEncoder().encode("+ok=\r\n"));
+        return;
+      }
+
+      // 8 条核心 AT 查询 — 走 atResponse 生成响应
+      const response = atResponse(str, this.config);
+      await this.tcp.send(new TextEncoder().encode(response + "\r\n"));
+      this.emit("log", `at resp: ${response}`);
+    } else {
+      // 透传数据（Phase 2 走硬件设备）
+      this.emit("log", `passthrough: ${str.trim()}`);
+    }
+  }
+
+  /**
+   * TCP 关闭
+   */
+  private onTcpClose(): void {
+    this.connected = false;
+    this.registered = false;
+    this.emit("log", "tcp closed");
+    this.scheduleReconnect();
+  }
+
+  /**
+   * 退避重连
+   */
+  private scheduleReconnect(): void {
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      this.emit("log", "max reconnect attempts reached, giving up");
+      return;
+    }
+    this.reconnectAttempts++;
+    // 跟 UartNode 端 src/dtus/state.ts:computeReconnectBackoff 1:1
+    // baseMs = min(16_000, 1000 * 2^(attempt-1)) + jitter
+    const baseMs = Math.min(16_000, 1000 * 2 ** (this.reconnectAttempts - 1));
+    const jitter = Math.random() * 500;
+    const waitMs = Math.round(baseMs + jitter);
+    this.emit("log", `reconnect ${this.reconnectAttempts}/${this.maxReconnectAttempts} in ${waitMs}ms`);
+    this.reconnectTimer = setTimeout(() => this.connect(), waitMs);
+  }
+
+  /**
+   * 获取本机 hostname
+   */
+  private async getHostname(): Promise<string | null> {
+    try {
+      // Deno 没有直接 os.hostname()，用 hostname 命令
+      const cmd = new Deno.Command("hostname", { stdout: "piped" });
+      const { stdout } = await cmd.output();
+      return new TextDecoder().decode(stdout).trim();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/soft-dtu/src/protocol/cellular-dtu.ts
+++ b/packages/soft-dtu/src/protocol/cellular-dtu.ts
@@ -24,6 +24,9 @@
  *   - 协议定义本地 hardcode（src/protocol/protocol-catalog.ts）
  */
 
+// I2: Node setTimeout 返回 NodeJS.Timeout 对象, 跟 Deno setTimeout 返回 number 类型冲突
+// 软 DTU 同时跑在 Deno runtime, 用 ReturnType<typeof setTimeout> 自动跟随当前 runtime
+// (Deno 时 number, Node 时 Timeout — 都能被 clearTimeout 接受, 实现 OK)
 import { EventEmitter } from "node:events";
 import type { TcpTransport } from "../transport/tcp.ts";
 import type { SoftDtuConfig } from "./config.ts";
@@ -41,7 +44,8 @@ export class CellularDtu extends EventEmitter {
   private registered = false;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
-  private reconnectTimer: number | null = null;
+  /** I2: 兼容 Node (NodeJS.Timeout) + Deno (number) 两种 setTimeout 返回类型 */
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(opts: CellularDtuOptions) {
     super();

--- a/packages/soft-dtu/src/protocol/config.ts
+++ b/packages/soft-dtu/src/protocol/config.ts
@@ -1,0 +1,132 @@
+/**
+ * 软 DTU 配置
+ *
+ * 启动时读：
+ *   - 虚拟 IMEI（dev 用，避免跟真硬件 IMEI 冲突；server 端按 mac 查 device profile）
+ *   - 设备 PID / VER / ICCID（伪装成汉枫 HF2411 4G DTU）
+ *   - UartNode host:port（数据通道，跟普通硬件 DTU 一样）
+ *   - uart-server URL（元数据通道，HTTP API 拉协议定义）
+ *   - 默认串口参数（baudRate / dataBits / stopBits / parity）
+ *
+ * 配置来源（优先级从高到低）：
+ *   1. 环境变量（container / shell 注入）
+ *   2. ~/.config/soft-dtu/config.json（用户 home 目录持久化）
+ *   3. 默认值（dev fallback）
+ *
+ * 全 env 驱动模式（跟 UartNode config.ts 风格对齐）：
+ *   - 避免 NODE_ENV / isProd 模式判断
+ *   - bun build / deno compile 静态分析时不会 DCE 掉 prod 分支
+ *
+ * 跟 server 端的关系（Cairui 2026-07-14 16:29 + 16:35 拍板）：
+ *   - 软 DTU 走 HTTP API 从 server 拉协议定义
+ *   - HTTP API 不鉴权（dev/内网）
+ *   - 不连 Socket.IO（src/transport/socketio.ts 废弃，commit 时 git rm）
+ *   - 跟普通硬件 DTU 一样走 TCP 9000 + 4G 协议（数据通道）
+ *   - server 端 0 改动需要 ping agent-ae682922673b 加 GET /api/v2/protocols 端点
+ *   - 协议让用户手动选，UI 启动不预选（cairui 2026-07-14 16:35 拍板）
+ */
+
+import { exists } from "jsr:@std/fs@^1.0.0/exists";
+import { join } from "jsr:@std/path@^1.0.0/join";
+
+export interface SoftDtuConfig {
+  /** 虚拟 IMEI（15 位，跟硬件 DTU 一样）*/
+  virtualImei: string;
+  /** DTU 设备型号（汉枫 HF2411）*/
+  pid: string;
+  /** 固件版本 */
+  ver: string;
+  /** GPRS 版本 */
+  gver: string;
+  /** ICCID（SIM 卡号，软 DTU 随便填）*/
+  iccid: string;
+  /** IOT 平台状态（on / off）*/
+  iotStat: string;
+  /** 初始信号强度（0-31）*/
+  signal: number;
+  /** UartNode 接入点（数据通道）*/
+  uartNode: {
+    host: string;
+    port: number;
+  };
+  /** uart-server 接入点（元数据通道，HTTP API 拉协议，不鉴权）*/
+  uartServer: {
+    url: string;
+    /** API 路径前缀，默认 /api/v2 */
+    apiPath: string;
+    /** 鉴权 token（dev 空，生产可填，但当前契约是不鉴权）*/
+    apiToken: string;
+    /** HTTP 请求超时（ms）*/
+    timeoutMs: number;
+  };
+  /** 默认串口参数（跟 XCOM / sscom 默认值对齐：115200/8/N/1）*/
+  defaultSerial: {
+    baudRate: number;
+    dataBits: 5 | 6 | 7 | 8;
+    stopBits: 1 | 2;
+    parity: "none" | "even" | "odd" | "mark" | "space";
+  };
+}
+
+const DEFAULT_CONFIG: SoftDtuConfig = {
+  virtualImei: Deno.env.get("SOFT_DTU_IMEI") ?? "358700000000123",
+  pid: Deno.env.get("SOFT_DTU_PID") ?? "HF2411",
+  ver: Deno.env.get("SOFT_DTU_VER") ?? "V3.0.0",
+  gver: Deno.env.get("SOFT_DTU_GVER") ?? "G4",
+  iccid: Deno.env.get("SOFT_DTU_ICCID") ?? "89860117851000012345",
+  iotStat: Deno.env.get("SOFT_DTU_IOTSTAT") ?? "on",
+  signal: Deno.env.get("SOFT_DTU_SIGNAL") ? Number(Deno.env.get("SOFT_DTU_SIGNAL")) : 20,
+  uartNode: {
+    host: Deno.env.get("UART_NODE_HOST") ?? "127.0.0.1",
+    port: Number(Deno.env.get("UART_NODE_PORT") ?? 9000),
+  },
+  uartServer: {
+    url: Deno.env.get("UART_SERVER_URL") ?? "http://127.0.0.1:9010",
+    apiPath: Deno.env.get("UART_SERVER_API_PATH") ?? "/api/v2",
+    apiToken: Deno.env.get("UART_SERVER_API_TOKEN") ?? "", // 当前契约不鉴权，保留字段兼容未来
+    timeoutMs: Number(Deno.env.get("UART_SERVER_TIMEOUT_MS") ?? 10_000),
+  },
+  defaultSerial: {
+    baudRate: 115200,
+    dataBits: 8,
+    stopBits: 1,
+    parity: "none",
+  },
+};
+
+/**
+ * 加载配置（env > home config > default）
+ */
+export async function loadConfig(): Promise<SoftDtuConfig> {
+  // 1. env 覆盖
+  const fromEnv: Partial<SoftDtuConfig> = {
+    virtualImei: Deno.env.get("SOFT_DTU_IMEI"),
+    pid: Deno.env.get("SOFT_DTU_PID"),
+    ver: Deno.env.get("SOFT_DTU_VER"),
+    gver: Deno.env.get("SOFT_DTU_GVER"),
+    iccid: Deno.env.get("SOFT_DTU_ICCID"),
+    iotStat: Deno.env.get("SOFT_DTU_IOTSTAT"),
+    signal: Deno.env.get("SOFT_DTU_SIGNAL") ? Number(Deno.env.get("SOFT_DTU_SIGNAL")) : undefined,
+  };
+
+  // 2. home config
+  const home = Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE") ?? "/tmp";
+  const configPath = join(home, ".config", "soft-dtu", "config.json");
+  let fromHome: Partial<SoftDtuConfig> = {};
+  if (await exists(configPath)) {
+    try {
+      const text = await Deno.readTextFile(configPath);
+      fromHome = JSON.parse(text);
+      console.log(`[config] loaded from ${configPath}`);
+    } catch (err) {
+      console.warn(`[config] failed to parse ${configPath}:`, err);
+    }
+  }
+
+  // 3. merge (env > home > default)
+  return {
+    ...DEFAULT_CONFIG,
+    ...fromHome,
+    ...Object.fromEntries(Object.entries(fromEnv).filter(([_, v]) => v !== undefined)),
+  };
+}

--- a/packages/soft-dtu/src/protocol/protocol-catalog.ts
+++ b/packages/soft-dtu/src/protocol/protocol-catalog.ts
@@ -113,12 +113,19 @@ export class ProtocolRepository {
   private lastFetch = 0;
   private readonly cacheTtlMs: number;
   private readonly baseUrl: string;
+  private readonly apiPath: string;
   private readonly timeoutMs: number;
   private fetching: Promise<ProtocolDefinition[]> | null = null;
   private readonly updateHandlers = new Set<(p: ProtocolDefinition[]) => void>();
 
-  constructor(opts: { baseUrl: string; cacheTtlMs?: number; timeoutMs?: number }) {
+  constructor(opts: {
+    baseUrl: string;
+    apiPath?: string;
+    cacheTtlMs?: number;
+    timeoutMs?: number;
+  }) {
     this.baseUrl = opts.baseUrl.replace(/\/$/, "");
+    this.apiPath = (opts.apiPath ?? "/api/v2").replace(/\/$/, "");
     this.cacheTtlMs = opts.cacheTtlMs ?? 5 * 60_000;
     this.timeoutMs = opts.timeoutMs ?? 10_000;
   }
@@ -179,7 +186,7 @@ export class ProtocolRepository {
    * 鉴权：D1=i 不鉴权（dev/内网），生产要加 Bearer token
    */
   private async fetchFromServer(): Promise<ProtocolDefinition[]> {
-    const url = `${this.baseUrl}/api/v2/protocols`;
+    const url = `${this.baseUrl}${this.apiPath}/protocols`;
     console.log(`[protocol-catalog] fetching ${url}`);
     try {
       const res = await fetch(url, {
@@ -193,11 +200,19 @@ export class ProtocolRepository {
         throw new Error(`HTTP ${res.status} ${res.statusText}`);
       }
       const data = await res.json();
-      if (!data || !Array.isArray(data.protocols)) {
-        throw new Error(`invalid response: protocols field not found`);
+      // 兼容 midwayuartserver 全局 `ResultSerializationMiddleware` 的 {code, data, ...} 包装
+      // 也兼容裸响应 {protocols: [...]}（未来 Phase 2 切换其他 server 时可能用）
+      // 详见 .harness/docs/server-api-contract.md "Response envelope" 段
+      const protocolsRaw: unknown = (data as any)?.data?.protocols ?? (data as any)?.protocols;
+      if (!Array.isArray(protocolsRaw)) {
+        throw new Error(
+          `invalid response: protocols field not found (got keys: ${
+            Object.keys(data || {}).join(",")
+          })`,
+        );
       }
       // schema 校验（轻量）
-      const protocols: ProtocolDefinition[] = data.protocols.map((p: any, idx: number) => {
+      const protocols: ProtocolDefinition[] = (protocolsRaw as any[]).map((p: any, idx: number) => {
         if (!p.id || !p.name || !p.type) {
           throw new Error(`protocol[${idx}] missing required fields: id/name/type`);
         }

--- a/packages/soft-dtu/src/protocol/protocol-catalog.ts
+++ b/packages/soft-dtu/src/protocol/protocol-catalog.ts
@@ -1,0 +1,228 @@
+/**
+ * 协议目录 — 软 DTU 走 HTTP API 从 server 拉协议定义
+ *
+ * 数据通道：软 DTU 跟普通硬件 DTU 一样走 TCP 9000 4G 协议，UartNode 代理上行
+ * 元数据通道：软 DTU 走 HTTP API GET /api/v2/protocols 拉协议定义（硬件 DTU 固件内固化）
+ *
+ * 优势：
+ *   - 协议定义 server 端集中管理，加新协议不动软 DTU
+ *   - 软 DTU 启动拉一次，5min 缓存 + offline fallback
+ *   - 不用刷固件就能支持新协议
+ *
+ * 跟 server 端对接（待 ping agent-ae682922673b 加）：
+ *   - 端点：GET {uartServer.url}/api/v2/protocols
+ *   - 鉴权：D1=i 沿用不鉴权（dev/内网），生产要加 Bearer token
+ *   - 响应 schema：{ protocols: ProtocolDefinition[] }
+ *
+ * Phase 1 范围：从 server 拉汉枫 4G / Modbus RTU 等协议
+ * Phase 2 扩展：协议定义可以加 version 字段，server 端按 version 下发，软 DTU 按需升级
+ *
+ * 离线 fallback（server 不可达时）：
+ *   - Modbus RTU 默认（公开标准，hardcode 安全）
+ *   - 警告用户"协议目录是离线模式，新协议不可用"
+ */
+
+export interface AtCommandDefinition {
+  name: string;
+  cmd: string;
+  parse: string; // 正则字符串
+  description?: string;
+}
+
+export interface RegisterDefinition {
+  /** 注册包格式（带 %MAC / %HOST 占位符）*/
+  format: string;
+  /** IMEI 位数（汉枫 15 位）*/
+  imeiLength: number;
+  /** 是否在 UartNode 推 +++AT+ 仪式后才发 */
+  triggerOnInvite: boolean;
+}
+
+export interface ProtocolDefinition {
+  id: string;
+  name: string;
+  type: "cellular-4g-dtu" | "modbus-rtu" | "lan-gateway" | "uart-direct";
+  manufacturer?: string;
+  model?: string;
+  category?: string;
+  version?: string; // 协议定义版本，server 端可加
+  metadata?: Record<string, string>;
+  atCommands?: AtCommandDefinition[];
+  /** modbus 寄存器表（485 协议用，Phase 2）*/
+  registers?: Array<{
+    address: number;
+    name: string;
+    type: "coil" | "discrete" | "holding" | "input";
+    dataType: "uint16" | "int16" | "uint32" | "int32" | "float" | "double";
+    unit?: string;
+    scale?: number;
+    description?: string;
+  }>;
+  /** 注册包定义（4G 协议用）*/
+  register?: RegisterDefinition;
+  /** 默认串口参数（485 协议用）*/
+  defaultSerial?: {
+    baudRate: number;
+    dataBits: 5 | 6 | 7 | 8;
+    stopBits: 1 | 2;
+    parity: "none" | "even" | "odd" | "mark" | "space";
+  };
+  /** 传输层配置 */
+  transport?: "tcp:9000" | "serial" | "tcp:custom";
+}
+
+/**
+ * 离线 fallback — server 不可达时使用
+ *
+ * 只放公开标准的协议（modbus RTU），不放专有协议（汉枫 4G）
+ * 避免 server 不可达时假装支持汉枫协议
+ */
+export const OFFLINE_FALLBACK: ProtocolDefinition[] = [
+  {
+    id: "modbus-rtu-default",
+    name: "Modbus RTU RS485 默认 (离线 fallback)",
+    type: "modbus-rtu",
+    category: "工业总线",
+    metadata: {
+      note: "server 不可达时的 fallback，公开标准协议",
+    },
+    registers: [
+      { address: 0, name: "电压", type: "input", dataType: "uint16", unit: "V", scale: 0.1, description: "电网电压" },
+      { address: 1, name: "电流", type: "input", dataType: "uint16", unit: "A", scale: 0.01, description: "负载电流" },
+      { address: 2, name: "功率", type: "input", dataType: "uint32", unit: "W", description: "有功功率" },
+      { address: 100, name: "设备地址", type: "holding", dataType: "uint16", description: "从站地址 (1-247)" },
+    ],
+    defaultSerial: {
+      baudRate: 9600,
+      dataBits: 8,
+      stopBits: 1,
+      parity: "even", // modbus RTU 标准
+    },
+    transport: "serial",
+  },
+];
+
+/**
+ * 协议仓库 — HTTP fetch + 缓存 + offline fallback
+ *
+ * 不依赖 socket.io-client，纯 HTTP fetch
+ * 5min 缓存避免每个 UI 操作都打 server
+ */
+export class ProtocolRepository {
+  private cache: ProtocolDefinition[] = [];
+  private lastFetch = 0;
+  private readonly cacheTtlMs: number;
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private fetching: Promise<ProtocolDefinition[]> | null = null;
+  private readonly updateHandlers = new Set<(p: ProtocolDefinition[]) => void>();
+
+  constructor(opts: { baseUrl: string; cacheTtlMs?: number; timeoutMs?: number }) {
+    this.baseUrl = opts.baseUrl.replace(/\/$/, "");
+    this.cacheTtlMs = opts.cacheTtlMs ?? 5 * 60_000;
+    this.timeoutMs = opts.timeoutMs ?? 10_000;
+  }
+
+  /**
+   * 获取协议列表（带缓存）
+   */
+  async list(): Promise<ProtocolDefinition[]> {
+    const now = Date.now();
+    if (this.cache.length > 0 && now - this.lastFetch < this.cacheTtlMs) {
+      return this.cache;
+    }
+    // 防止并发 fetch
+    if (this.fetching) {
+      return this.fetching;
+    }
+    this.fetching = this.fetchFromServer().finally(() => {
+      this.fetching = null;
+    });
+    return this.fetching;
+  }
+
+  /**
+   * 强制刷新（忽略缓存）
+   */
+  async refresh(): Promise<ProtocolDefinition[]> {
+    this.lastFetch = 0;
+    return this.list();
+  }
+
+  /**
+   * 按 ID 查询（从缓存）
+   */
+  get(id: string): ProtocolDefinition | undefined {
+    return this.cache.find((p) => p.id === id);
+  }
+
+  /**
+   * 协议更新回调（WebView 订阅）
+   */
+  onUpdate(handler: (protocols: ProtocolDefinition[]) => void): () => void {
+    this.updateHandlers.add(handler);
+    return () => this.updateHandlers.delete(handler);
+  }
+
+  /**
+   * 当前是否处于离线模式
+   */
+  isOffline(): boolean {
+    return this.cache.length === 0 || this.cache === OFFLINE_FALLBACK;
+  }
+
+  /**
+   * 实际从 server 拉协议定义
+   *
+   * 端点：GET {baseUrl}/api/v2/protocols
+   * 响应：{ protocols: ProtocolDefinition[] }
+   * 鉴权：D1=i 不鉴权（dev/内网），生产要加 Bearer token
+   */
+  private async fetchFromServer(): Promise<ProtocolDefinition[]> {
+    const url = `${this.baseUrl}/api/v2/protocols`;
+    console.log(`[protocol-catalog] fetching ${url}`);
+    try {
+      const res = await fetch(url, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+        },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      }
+      const data = await res.json();
+      if (!data || !Array.isArray(data.protocols)) {
+        throw new Error(`invalid response: protocols field not found`);
+      }
+      // schema 校验（轻量）
+      const protocols: ProtocolDefinition[] = data.protocols.map((p: any, idx: number) => {
+        if (!p.id || !p.name || !p.type) {
+          throw new Error(`protocol[${idx}] missing required fields: id/name/type`);
+        }
+        return p as ProtocolDefinition;
+      });
+      this.cache = protocols;
+      this.lastFetch = Date.now();
+      console.log(`[protocol-catalog] loaded ${protocols.length} protocols from server`);
+      // 通知订阅者
+      for (const h of this.updateHandlers) {
+        try {
+          h(this.cache);
+        } catch (err) {
+          console.warn(`[protocol-catalog] update handler error:`, err);
+        }
+      }
+      return this.cache;
+    } catch (err) {
+      const msg = (err as Error).message;
+      console.warn(`[protocol-catalog] fetch failed (${msg}), using ${this.cache.length > 0 ? "stale cache" : "offline fallback"}`);
+      if (this.cache.length === 0) {
+        this.cache = OFFLINE_FALLBACK;
+        this.lastFetch = Date.now(); // 避免重试
+      }
+      return this.cache;
+    }
+  }
+}

--- a/packages/soft-dtu/src/server/http-api.ts
+++ b/packages/soft-dtu/src/server/http-api.ts
@@ -18,18 +18,44 @@
  * （WebView 直接 IPC 调 bindings，不走 HTTP）
  */
 
-import type { SerialBindings, ProtocolBindings } from "../bindings/serial.ts";
+import type { SerialBindings } from "../bindings/serial.ts";
+import type { ProtocolBindings } from "../bindings/protocol.ts";
 
 interface HttpApiOptions {
   port: number;
   host: string;
 }
 
+/** I5: SSE 连接上限 + idle timeout, 防恶意跨域页 + 资源耗尽 */
+const SSE_MAX_PER_CHANNEL = 16;
+/** I5: SSE idle timeout (10min), 没活动就断 */
+const SSE_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
 export function startHttpApi(
   opts: HttpApiOptions,
   serial: SerialBindings,
   protocol: ProtocolBindings,
 ): Deno.HttpServer {
+  // I5: CORS env gate — loopback (dev) 放开, 非 loopback (生产) 走同源代理
+  const isLoopback = (opts.host === "127.0.0.1" || opts.host === "localhost" || opts.host === "::1");
+  /** JSON 响应 (根据 isLoopback 决定 CORS *) */
+  function jsonResponse(data: unknown, init?: ResponseInit): Response {
+    const headers: Record<string, string> = {
+      "content-type": "application/json; charset=utf-8",
+    };
+    if (isLoopback) {
+      headers["access-control-allow-origin"] = "*";
+    } else {
+      // 生产模式: 走 Vite proxy 同源, 不开 CORS *
+      // 如果真的需要跨域, 显式加 origin 白名单
+      headers["vary"] = "origin";
+    }
+    return new Response(JSON.stringify(data), {
+      ...init,
+      headers: { ...headers, ...(init?.headers ?? {}) },
+    });
+  }
+
   const sseClients: Map<string, Set<ReadableStreamDefaultController<Uint8Array>>> = new Map();
 
   /** 广播 SSE 事件到对应 channel 的所有客户端 */
@@ -63,34 +89,24 @@ export function startHttpApi(
     sseBroadcast("close", "close", {});
   });
 
-  /** JSON 响应 */
-  function jsonResponse(data: unknown, init?: ResponseInit): Response {
-    return new Response(JSON.stringify(data), {
-      ...init,
-      headers: {
-        "content-type": "application/json; charset=utf-8",
-        "access-control-allow-origin": "*", // dev only
-        ...(init?.headers ?? {}),
-      },
-    });
-  }
-
   /** 错误响应 */
   function errorResponse(status: number, message: string): Response {
     return jsonResponse({ error: message }, { status });
   }
 
-  /** CORS preflight */
+  /** CORS preflight (I5: loopback 才开 *) */
   function corsPreflight(): Response {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, POST, OPTIONS",
-        "access-control-allow-headers": "content-type",
-        "access-control-max-age": "86400",
-      },
-    });
+    const headers: Record<string, string> = {
+      "access-control-allow-methods": "GET, POST, OPTIONS",
+      "access-control-allow-headers": "content-type",
+      "access-control-max-age": "86400",
+    };
+    if (isLoopback) {
+      headers["access-control-allow-origin"] = "*";
+    } else {
+      headers["vary"] = "origin";
+    }
+    return new Response(null, { status: 204, headers });
   }
 
   /** 读 JSON body */
@@ -140,15 +156,23 @@ export function startHttpApi(
       }
 
       if (path === "/api/serial/write" && method === "POST") {
-        const body = (await readJson(req)) as { data?: string } | null;
+        // I4: 显式 encoding — 不再启发式猜 base64, 4 字符 ASCII ("ATEN"/"INFO"/"1234") 会被误判
+        // 默认 utf8, 跟 webview api.ts:serial.write 同步
+        const body = (await readJson(req)) as
+          | { data?: string; encoding?: "utf8" | "base64" }
+          | null;
         if (!body?.data) {
           return errorResponse(400, "missing data");
         }
-        // 启发式判断：纯 ASCII 文本 → string；否则 → base64
-        const isLikelyBase64 = /^[A-Za-z0-9+/]+=*$/.test(body.data) && body.data.length % 4 === 0;
-        const data = isLikelyBase64 && body.data.length > 0
-          ? base64ToBytes(body.data)
-          : body.data; // 字符串直接传
+        const encoding = body.encoding ?? "utf8";
+        let data: string | Uint8Array;
+        if (encoding === "base64") {
+          data = base64ToBytes(body.data);
+        } else if (encoding === "utf8") {
+          data = body.data; // 直接传 string, serial.write 会 TextEncoder.encode
+        } else {
+          return errorResponse(400, `unsupported encoding: ${encoding}`);
+        }
         await serial.write(data);
         return jsonResponse({ ok: true });
       }
@@ -165,30 +189,61 @@ export function startHttpApi(
         if (!["data", "error", "close"].includes(channel)) {
           return errorResponse(400, "invalid channel (data|error|close)");
         }
+        // I5: SSE 连接上限 — 防止恶意跨域页 / 资源耗尽
         let set = sseClients.get(channel);
         if (!set) {
           set = new Set();
           sseClients.set(channel, set);
         }
+        if (set.size >= SSE_MAX_PER_CHANNEL) {
+          return errorResponse(429, `SSE channel ${channel} full (${set.size}/${SSE_MAX_PER_CHANNEL})`);
+        }
         const encoder = new TextEncoder();
+        // C2: hoist ctrl 到外层, 让 cancel() 能拿到
+        let myController: ReadableStreamDefaultController<Uint8Array> | null = null;
+        // I5: idle timeout — 10min 无活动自动 close
+        // I2 兼容: 跟 cellular-dtu.ts 一样, ReturnType<typeof setTimeout> 自动跟随当前 runtime
+        let idleTimeout: ReturnType<typeof setTimeout> | null = null;
         const stream = new ReadableStream<Uint8Array>({
           start(ctrl) {
+            myController = ctrl;
             set!.add(ctrl);
             // 立刻推一个 connected 事件让客户端知道 SSE 通了
             ctrl.enqueue(encoder.encode(`event: connected\ndata: ${JSON.stringify({ channel })}\n\n`));
+            // I5: idle timeout
+            idleTimeout = setTimeout(() => {
+              try {
+                ctrl.close();
+              } catch { /* 已被 close */ }
+              if (myController) {
+                set!.delete(myController);
+                myController = null;
+              }
+            }, SSE_IDLE_TIMEOUT_MS);
           },
           cancel() {
-            set!.delete(ctrl);
+            // C2 修: 用外层 hoisted 引用, 不再 ReferenceError
+            if (idleTimeout !== null) {
+              clearTimeout(idleTimeout);
+              idleTimeout = null;
+            }
+            if (myController) {
+              set!.delete(myController);
+              myController = null;
+            }
           },
         });
-        return new Response(stream, {
-          headers: {
-            "content-type": "text/event-stream",
-            "cache-control": "no-cache",
-            "connection": "keep-alive",
-            "access-control-allow-origin": "*",
-          },
-        });
+        const sseHeaders: Record<string, string> = {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          "connection": "keep-alive",
+        };
+        if (isLoopback) {
+          sseHeaders["access-control-allow-origin"] = "*";
+        } else {
+          sseHeaders["vary"] = "origin";
+        }
+        return new Response(stream, { headers: sseHeaders });
       }
 
       // ── Protocol ──

--- a/packages/soft-dtu/src/server/http-api.ts
+++ b/packages/soft-dtu/src/server/http-api.ts
@@ -1,0 +1,221 @@
+/**
+ * 软 DTU HTTP API server (Phase 1 stub)
+ *
+ * 把 bindings 包装成 HTTP 端点，WebView 走 fetch 调过来
+ * Vite dev server proxy /api/* → 这个 serve
+ *
+ * 端点：
+ *   - GET  /api/serial/list          → SerialPortInfo[]
+ *   - POST /api/serial/open          → { path, options } → { ok: true }
+ *   - POST /api/serial/close         → { ok: true }
+ *   - POST /api/serial/write         → { data: string | base64 } → { ok: true }
+ *   - GET  /api/serial/status        → { isOpen, currentPort }
+ *   - GET  /api/serial/stream?channel=data|error|close → SSE
+ *   - GET  /api/protocols            → { protocols: ProtocolDefinition[] }
+ *   - GET  /api/protocols/refresh    → { protocols: ProtocolDefinition[] }
+ *
+ * Phase 2 切 Deno Desktop official bindings SDK 后可以删这个文件
+ * （WebView 直接 IPC 调 bindings，不走 HTTP）
+ */
+
+import type { SerialBindings, ProtocolBindings } from "../bindings/serial.ts";
+
+interface HttpApiOptions {
+  port: number;
+  host: string;
+}
+
+export function startHttpApi(
+  opts: HttpApiOptions,
+  serial: SerialBindings,
+  protocol: ProtocolBindings,
+): Deno.HttpServer {
+  const sseClients: Map<string, Set<ReadableStreamDefaultController<Uint8Array>>> = new Map();
+
+  /** 广播 SSE 事件到对应 channel 的所有客户端 */
+  function sseBroadcast(channel: string, eventName: string, payload: unknown) {
+    const clients = sseClients.get(channel);
+    if (!clients || clients.size === 0) return;
+    const encoder = new TextEncoder();
+    const data = `event: ${eventName}\ndata: ${JSON.stringify(payload)}\n\n`;
+    const bytes = encoder.encode(data);
+    for (const ctrl of clients) {
+      try {
+        ctrl.enqueue(bytes);
+      } catch {
+        // 客户端已断开 — 从集合里移除
+        clients.delete(ctrl);
+      }
+    }
+  }
+
+  // 订阅 serial 事件 → SSE 广播
+  serial.onData((data) => {
+    // Uint8Array → base64
+    let bin = "";
+    for (let i = 0; i < data.length; i++) bin += String.fromCharCode(data[i]);
+    sseBroadcast("data", "data", { bytes: btoa(bin) });
+  });
+  serial.onError((err) => {
+    sseBroadcast("error", "error", { message: err.message });
+  });
+  serial.onClose(() => {
+    sseBroadcast("close", "close", {});
+  });
+
+  /** JSON 响应 */
+  function jsonResponse(data: unknown, init?: ResponseInit): Response {
+    return new Response(JSON.stringify(data), {
+      ...init,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "access-control-allow-origin": "*", // dev only
+        ...(init?.headers ?? {}),
+      },
+    });
+  }
+
+  /** 错误响应 */
+  function errorResponse(status: number, message: string): Response {
+    return jsonResponse({ error: message }, { status });
+  }
+
+  /** CORS preflight */
+  function corsPreflight(): Response {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, POST, OPTIONS",
+        "access-control-allow-headers": "content-type",
+        "access-control-max-age": "86400",
+      },
+    });
+  }
+
+  /** 读 JSON body */
+  async function readJson(req: Request): Promise<unknown> {
+    try {
+      return await req.json();
+    } catch {
+      return null;
+    }
+  }
+
+  /** base64 → Uint8Array */
+  function base64ToBytes(b64: string): Uint8Array {
+    const bin = atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+    return arr;
+  }
+
+  const handler = async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const path = url.pathname;
+    const method = req.method;
+
+    // CORS preflight
+    if (method === "OPTIONS") return corsPreflight();
+
+    try {
+      // ── Serial ──
+      if (path === "/api/serial/list" && method === "GET") {
+        const list = await serial.list();
+        return jsonResponse(list);
+      }
+
+      if (path === "/api/serial/open" && method === "POST") {
+        const body = (await readJson(req)) as { path?: string; options?: unknown } | null;
+        if (!body?.path || !body.options) {
+          return errorResponse(400, "missing path or options");
+        }
+        await serial.open(body.path, body.options as Parameters<typeof serial.open>[1]);
+        return jsonResponse({ ok: true });
+      }
+
+      if (path === "/api/serial/close" && method === "POST") {
+        await serial.close();
+        return jsonResponse({ ok: true });
+      }
+
+      if (path === "/api/serial/write" && method === "POST") {
+        const body = (await readJson(req)) as { data?: string } | null;
+        if (!body?.data) {
+          return errorResponse(400, "missing data");
+        }
+        // 启发式判断：纯 ASCII 文本 → string；否则 → base64
+        const isLikelyBase64 = /^[A-Za-z0-9+/]+=*$/.test(body.data) && body.data.length % 4 === 0;
+        const data = isLikelyBase64 && body.data.length > 0
+          ? base64ToBytes(body.data)
+          : body.data; // 字符串直接传
+        await serial.write(data);
+        return jsonResponse({ ok: true });
+      }
+
+      if (path === "/api/serial/status" && method === "GET") {
+        return jsonResponse({
+          isOpen: serial.isOpen(),
+          currentPort: serial.currentPort(),
+        });
+      }
+
+      if (path === "/api/serial/stream" && method === "GET") {
+        const channel = url.searchParams.get("channel") ?? "data";
+        if (!["data", "error", "close"].includes(channel)) {
+          return errorResponse(400, "invalid channel (data|error|close)");
+        }
+        let set = sseClients.get(channel);
+        if (!set) {
+          set = new Set();
+          sseClients.set(channel, set);
+        }
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream<Uint8Array>({
+          start(ctrl) {
+            set!.add(ctrl);
+            // 立刻推一个 connected 事件让客户端知道 SSE 通了
+            ctrl.enqueue(encoder.encode(`event: connected\ndata: ${JSON.stringify({ channel })}\n\n`));
+          },
+          cancel() {
+            set!.delete(ctrl);
+          },
+        });
+        return new Response(stream, {
+          headers: {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            "connection": "keep-alive",
+            "access-control-allow-origin": "*",
+          },
+        });
+      }
+
+      // ── Protocol ──
+      if (path === "/api/protocols" && method === "GET") {
+        const list = await protocol.list();
+        return jsonResponse({ protocols: list, offline: protocol.isOffline() });
+      }
+
+      if (path === "/api/protocols/refresh" && method === "GET") {
+        const list = await protocol.refresh();
+        return jsonResponse({ protocols: list, offline: protocol.isOffline() });
+      }
+
+      // ── Health ──
+      if (path === "/api/health" && method === "GET") {
+        return jsonResponse({ ok: true, ts: Date.now() });
+      }
+
+      return errorResponse(404, `not found: ${method} ${path}`);
+    } catch (err) {
+      return errorResponse(500, (err as Error).message);
+    }
+  };
+
+  const server = Deno.serve({ port: opts.port, hostname: opts.host, onListen: ({ port, hostname }) => {
+    console.log(`[http-api] listening on http://${hostname}:${port}/api/*`);
+  } }, handler);
+
+  return server;
+}

--- a/packages/soft-dtu/src/transport/serial.ts
+++ b/packages/soft-dtu/src/transport/serial.ts
@@ -1,0 +1,142 @@
+/**
+ * 串口 Transport — USB 转 485 设备通信
+ *
+ * 用 npm:serialport（Deno 1.4+ 支持 npm specifier）
+ *
+ * 行为：
+ *   - list(): 列出本机可用串口（/dev/tty.usbserial-* on macOS, /dev/ttyUSB* on Linux, COM* on Windows）
+ *   - open(path, options): 打开串口
+ *   - write(data): 发数据到 RS485 设备
+ *   - on("data", ...): 收 RS485 设备响应
+ *   - close(): 关闭串口
+ *
+ * macOS 上常见 USB 转串口芯片：
+ *   - CH340 / CH341（最常见，便宜）
+ *   - CP2102 / CP2104（Silicon Labs）
+ *   - FT232（FTDI）
+ *   - PL2303（Prolific）
+ *
+ * macOS 13+ 内置 CH340/CH343/CH9102/CP210x/FTDI 驱动，旧版需要装：
+ *   - CH340: https://www.wch-ic.com/downloads/CH341SER_MAC_V1.7.html
+ *   - CP2102: 内置（macOS 10.9+）
+ *   - FT232: 内置
+ *
+ * 485 设备最常见是 Modbus RTU 协议：
+ *   - npm:modbus-serial（Phase 2 加）
+ *   - 软 DTU 当 master，485 设备当 slave
+ *   - 软 DTU 同时连 UartNode（4G 协议）+ 串口（modbus RTU）
+ *   - UartNode ←→ 软 DTU ←→ 485 设备
+ */
+
+import { EventEmitter } from "node:events";
+import { SerialPort } from "serialport";
+
+export interface SerialPortInfo {
+  path: string;
+  manufacturer?: string;
+  productId?: string;
+  vendorId?: string;
+}
+
+export interface SerialOptions {
+  baudRate: number;
+  dataBits?: 5 | 6 | 7 | 8;
+  stopBits?: 1 | 2;
+  parity?: "none" | "even" | "odd" | "mark" | "space";
+  /** 软 DTU 独占还是共享（macOS 不支持共享，Linux/Mac 都 true）*/
+  lock?: boolean;
+}
+
+export class SerialTransport extends EventEmitter {
+  private port: SerialPort | null = null;
+
+  /**
+   * 列出本机可用串口
+   */
+  static async list(): Promise<SerialPortInfo[]> {
+    const ports = await SerialPort.list();
+    return ports.map((p) => ({
+      path: p.path,
+      manufacturer: p.manufacturer,
+      productId: p.productId,
+      vendorId: p.vendorId,
+    }));
+  }
+
+  /**
+   * 打开串口
+   */
+  async open(path: string, options: SerialOptions): Promise<void> {
+    if (this.port) {
+      throw new Error("serial port already open");
+    }
+    this.port = new SerialPort({
+      path,
+      baudRate: options.baudRate,
+      dataBits: options.dataBits ?? 8,
+      stopBits: options.stopBits ?? 1,
+      parity: options.parity ?? "none",
+      lock: options.lock ?? true,
+      autoOpen: false,
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      this.port!.open((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        this.emit("log", `serial opened: ${path} @ ${options.baudRate} 8${options.parity?.[0]?.toUpperCase() ?? "N"}${options.stopBits ?? 1}`);
+        this.port!.on("data", (data: Buffer) => {
+          this.emit("data", new Uint8Array(data));
+        });
+        this.port!.on("error", (err: Error) => {
+          this.emit("error", err);
+        });
+        this.port!.on("close", () => {
+          this.emit("close");
+        });
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * 写数据到 485 设备
+   */
+  async write(data: Uint8Array): Promise<void> {
+    if (!this.port || !this.port.isOpen) {
+      throw new Error("serial port not open");
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.port!.write(Buffer.from(data), (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  /**
+   * 关闭串口
+   */
+  close(): void {
+    if (this.port) {
+      this.port.close();
+      this.port = null;
+    }
+  }
+
+  /**
+   * 当前是否打开
+   */
+  get isOpen(): boolean {
+    return this.port?.isOpen ?? false;
+  }
+}
+
+/**
+ * 顶层 list 函数（main.ts 直接调）
+ */
+export async function listSerialPorts(): Promise<SerialPortInfo[]> {
+  return SerialTransport.list();
+}

--- a/packages/soft-dtu/src/transport/tcp.ts
+++ b/packages/soft-dtu/src/transport/tcp.ts
@@ -1,0 +1,128 @@
+/**
+ * TCP Transport — 连 UartNode:9000
+ *
+ * 用 Deno 1.4+ 原生 Deno.connect()（不依赖 npm 包）
+ * 跟 UartNode 端 src/server/tcp-server.ts (Bun net.Server) 兼容
+ *
+ * 行为：
+ *   - 主动 connect UartNode:9000（软 DTU 是 client，UartNode 是 server）
+ *   - 处理 binary + text 双向数据
+ *   - 半关闭 + 重连支持
+ *
+ * 不依赖 UartNode PR #20 NODE_TOKEN（软 DTU 是设备层，不是 Node 层）
+ */
+
+import { EventEmitter } from "node:events";
+
+export interface TcpTransportOptions {
+  host: string;
+  port: number;
+  /** 读超时 (ms)，默认 0 = 不超时（UartNode setTimeout 5min 兜底）*/
+  readTimeoutMs?: number;
+}
+
+export class TcpTransport extends EventEmitter {
+  private readonly host: string;
+  private readonly port: number;
+  private readonly readTimeoutMs: number;
+  private conn: Deno.TcpConn | null = null;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(opts: TcpTransportOptions) {
+    super();
+    this.host = opts.host;
+    this.port = opts.port;
+    this.readTimeoutMs = opts.readTimeoutMs ?? 0;
+  }
+
+  /**
+   * 主动连 UartNode
+   */
+  async connect(): Promise<void> {
+    this.emit("log", `tcp.connect ${this.host}:${this.port}`);
+    this.conn = await Deno.connect({
+      hostname: this.host,
+      port: this.port,
+      transport: "tcp",
+    });
+    // TCP keepalive 跟 UartNode 端 socket.ts 对齐
+    try {
+      // Deno 1.40+ 支持 keepAlive，2.0 已 GA
+      (this.conn as unknown as { setKeepAlive: (enable: boolean, initialDelay?: number) => void })
+        .setKeepAlive(true, 100_000);
+    } catch {
+      // 旧 Deno 不支持，忽略
+    }
+    this.emit("log", "tcp connected");
+    this.startReadLoop();
+  }
+
+  /**
+   * 发送数据
+   */
+  async send(data: Uint8Array): Promise<void> {
+    if (!this.conn) {
+      throw new Error("tcp not connected");
+    }
+    // 串行化 write 避免 race
+    this.writeQueue = this.writeQueue.then(async () => {
+      if (this.conn) {
+        await this.conn.write(data);
+      }
+    });
+    return this.writeQueue;
+  }
+
+  /**
+   * 关闭连接
+   */
+  close(): void {
+    if (this.conn) {
+      try {
+        this.conn.close();
+      } catch {
+        // ignore
+      }
+      this.conn = null;
+    }
+    if (this.reader) {
+      try {
+        this.reader.cancel();
+      } catch {
+        // ignore
+      }
+      this.reader = null;
+    }
+    this.emit("close");
+  }
+
+  /**
+   * 读循环
+   */
+  private async startReadLoop(): Promise<void> {
+    if (!this.conn) return;
+    this.reader = this.conn.readable.getReader();
+    const decoder = new TextDecoder();
+
+    try {
+      while (true) {
+        const { value, done } = await this.reader.read();
+        if (done) {
+          this.emit("log", "tcp read EOF");
+          break;
+        }
+        if (value && value.length > 0) {
+          this.emit("data", value);
+          this.emit("log", `tcp <<< ${decoder.decode(value).trim()}`);
+        }
+      }
+    } catch (err) {
+      this.emit("error", err);
+    } finally {
+      this.reader?.releaseLock();
+      this.reader = null;
+      this.emit("close");
+    }
+  }
+}

--- a/packages/soft-dtu/webview/.gitignore
+++ b/packages/soft-dtu/webview/.gitignore
@@ -1,0 +1,20 @@
+# Vite + npm 标准忽略
+node_modules/
+dist/
+dist-ssr/
+*.local
+
+# 编辑器
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# 日志
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Vite cache
+.vite/

--- a/packages/soft-dtu/webview/README.md
+++ b/packages/soft-dtu/webview/README.md
@@ -1,0 +1,89 @@
+# 软 DTU WebView
+
+软 DTU 控制台 UI 层 — **Vite + Preact + TypeScript**
+
+## 4 个面板
+
+| 面板 | 功能 |
+|------|------|
+| **串口配置** | 列本机串口、设波特率/数据位/停止位/校验、open/close |
+| **AT 指令** | 发 `+++AT+XXX`、自动补全、解析响应（按选中协议的 `parse` 正则）|
+| **HEX/ASCII** | 实时订阅串口数据，HEX / ASCII / 双视图切换 |
+| **协议定义** | 浏览 server `/api/v2/protocols`、手动选协议、看 AT 指令 + 寄存器表 |
+
+## Dev 工作流（Phase 1）
+
+**双进程** — 软 DTU 后端（Deno）+ Vite dev server（Vite/Preact）：
+
+```bash
+# 终端 1：启动软 DTU 后端（Deno，HTTP serve on 127.0.0.1:8080）
+cd packages/soft-dtu
+deno task dev
+
+# 终端 2：启动 WebView（Vite dev server on 127.0.0.1:5173，代理 /api → 8080）
+cd packages/soft-dtu/webview
+npm install   # 第一次需要装依赖
+npm run dev
+```
+
+浏览器开 http://127.0.0.1:5173
+
+### Vite proxy 流程
+
+```
+浏览器 127.0.0.1:5173
+  ↓ fetch('/api/serial/list')
+Vite dev server (proxy /api/* → 8080)
+  ↓ http://127.0.0.1:8080/api/serial/list
+Deno main.ts (deno serve)
+  ↓ 调 __serialBindings.list()
+SerialTransport.list() → SerialPort.list()
+  ↓ 返回 SerialPortInfo[]
+```
+
+## Phase 2 切换
+
+Deno 2.9 稳定后，bindings 切到 Deno Desktop official SDK（直接 IPC，无 HTTP）：
+
+- `src/api.ts` 改用 `window.bindings.serial.*` 替代 fetch
+- Vite proxy 配置可以删（WebView 直接调 Deno runtime）
+- `deno desktop .` 启动原生窗口（macOS / Windows / Linux），bundle 内嵌 webview/dist 静态文件
+
+## 字段名约束 ⚠️
+
+`src/bindings.ts` 类型契约必须 **1:1 跟 Deno 端对齐**：
+
+- `src/bindings/serial.ts`（Deno 端）
+- `src/bindings/protocol.ts`（Deno 端）
+
+参考契约文档：`../.harness/docs/server-api-contract.md`
+
+**改字段名必 ping sibling**（user memory "跨 worker 字段名约定"）—— 错位会**静默失败**。
+
+## 文件结构
+
+```
+webview/
+├── package.json          # Vite + Preact + TS 依赖
+├── vite.config.ts        # dev proxy + preact preset
+├── tsconfig.json         # Preact JSX 配置
+├── index.html            # SPA 入口
+└── src/
+    ├── main.tsx          # Preact mount
+    ├── App.tsx           # Tab 路由
+    ├── bindings.ts       # 类型契约（1:1 跟 Deno 端对齐）
+    ├── api.ts            # HTTP fetch wrapper
+    ├── styles.css        # 暗色主题
+    └── panels/
+        ├── SerialConfig.tsx
+        ├── ATConsole.tsx
+        ├── HexView.tsx
+        └── ProtocolViewer.tsx
+```
+
+## 已知限制
+
+- **HTTP stub 模式**：Phase 1 webview 走 fetch（Vite proxy → Deno serve），不是原生 IPC
+- **SSE 单通道**：`onData` / `onError` / `onClose` 各开一个 EventSource，Phase 2 合并成单 IPC channel
+- **无单元测试**：跟 UartNode 一样，Phase 2 落地时加 vitest
+- **不预选协议**（Cairui 2026-07-14 16:35 拍板）：用户手动选

--- a/packages/soft-dtu/webview/index.html
+++ b/packages/soft-dtu/webview/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>软 DTU 控制台</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/soft-dtu/webview/package.json
+++ b/packages/soft-dtu/webview/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@uart-node/soft-dtu-webview",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "软 DTU WebView (Vite + Preact + TypeScript) — 串口配置 / AT 指令 / HEX-ASCII 切换 / 协议定义浏览器",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "preact": "^10.22.0"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.9.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/packages/soft-dtu/webview/src/App.tsx
+++ b/packages/soft-dtu/webview/src/App.tsx
@@ -1,0 +1,57 @@
+/**
+ * 软 DTU WebView 主组件 — Tab 路由
+ *
+ * 4 个面板：
+ *   1. SerialConfig  — 串口配置（选串口 + 波特率/数据位/停止位/校验）
+ *   2. ATConsole    — AT 指令控制台（发 +++AT+XXX + 自动补全）
+ *   3. HexView      — HEX/ASCII 实时数据视图
+ *   4. ProtocolViewer — 协议定义浏览器（手动选协议，看 AT 指令 + 寄存器表）
+ */
+
+import { useState } from "preact/hooks";
+import { SerialConfig } from "./panels/SerialConfig.tsx";
+import { ATConsole } from "./panels/ATConsole.tsx";
+import { HexView } from "./panels/HexView.tsx";
+import { ProtocolViewer } from "./panels/ProtocolViewer.tsx";
+
+type Tab = "serial" | "at" | "hex" | "protocol";
+
+const TABS: Array<{ id: Tab; label: string; hint: string }> = [
+  { id: "serial", label: "串口配置", hint: "选串口 + 波特率/数据位/停止位/校验" },
+  { id: "at", label: "AT 指令", hint: "发 +++AT+XXX + 自动补全" },
+  { id: "hex", label: "HEX/ASCII", hint: "实时数据流 HEX/ASCII 切换" },
+  { id: "protocol", label: "协议定义", hint: "从 server 拉的协议目录" },
+];
+
+export function App() {
+  const [tab, setTab] = useState<Tab>("serial");
+
+  return (
+    <div class="app">
+      <header class="app-header">
+        <h1>软 DTU 控制台</h1>
+        <span class="subtitle">UartNode · Deno Desktop · Phase 1</span>
+      </header>
+
+      <nav class="tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            class={`tab ${tab === t.id ? "active" : ""}`}
+            onClick={() => setTab(t.id)}
+            title={t.hint}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <main class="panel">
+        {tab === "serial" && <SerialConfig />}
+        {tab === "at" && <ATConsole />}
+        {tab === "hex" && <HexView />}
+        {tab === "protocol" && <ProtocolViewer />}
+      </main>
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/App.tsx
+++ b/packages/soft-dtu/webview/src/App.tsx
@@ -1,13 +1,16 @@
 /**
  * 软 DTU WebView 主组件 — Sidebar + Header + Status bar 布局
  *
- * 布局（Apple SF dark mode）：
- *   ┌─Sidebar(200px)─┐ ┌─Header(56px)────────────────────┐
+ * v2 接力（cairui 反馈）：暖橙调色板 + 12pt spacing + sidebar 220px +
+ * header 64px + 9 个新 icon + brand mark 换 IconLogo.
+ *
+ * 布局（工业控制台暖色调）：
+ *   ┌─Sidebar(220px)─┐ ┌─Header(64px)────────────────────┐
  *   │  透色 blur       │ │  软 DTU 控制台    [连接状态 pill]│
- *   │  ⚙ 软 DTU        │ ├─────────────────────────────────┤
+ *   │  📡 软 DTU       │ ├─────────────────────────────────┤
  *   │  • 串口配置 ⌘1   │ │                                 │
  *   │  • AT 指令  ⌘2   │ │  [Current panel content]        │
- *   │  • HEX/ASCII⌘3   │ │   - 24px padding                │
+ *   │  • HEX/ASCII⌘3   │ │   - 32px padding                │
  *   │  • 协议定义 ⌘4   │ │   - 卡片化表单                  │
  *   │  ⚙ 设置          │ │   - 表格 / 列表                  │
  *   │  ? 帮助          │ │                                 │
@@ -35,6 +38,11 @@
  *  11. Status bar "last sync" 指示 — 本文件 + Health check 5s 轮询
  *  12. Segmented control pill SF 风格 — styles.css .seg 微调
  *
+ * v2 接力补的 3 项（cairui 浏览器反馈）：
+ *   13. 9 个新 icon (Logo/Refresh/Send/Close/Trash/Play/Pause/Copy/Warning/Info) — icons.tsx
+ *   14. 暖橙调色板 + 12pt spacing grid + sidebar/header/padding 全放宽 — styles.css
+ *   15. 4 panel 按钮加 leading icon (Send/Close/Refresh/Trash/Play/Pause) — panels/*.tsx
+ *
  * Health check 走 /api/health（5s 轮询），protocol count 从 /api/protocols 拿。
  * last sync: health 200 时更新时间, 显示"已同步 HH:MM:SS" / "从未同步"。
  */
@@ -50,6 +58,7 @@ import {
   IconAT,
   IconHex,
   IconProtocol,
+  IconLogo,
   IconSettings,
   IconHelp,
 } from "./icons.tsx";
@@ -167,7 +176,7 @@ export function App() {
       <aside class="sidebar" aria-label="主导航">
         <div class="sidebar-brand">
           <span class="sidebar-brand-mark" aria-hidden="true">
-            <IconSettings />
+            <IconLogo />
           </span>
           <span>软 DTU</span>
         </div>
@@ -192,11 +201,11 @@ export function App() {
           })}
         </nav>
         <div class="sidebar-footer">
-          <button class="nav-item" disabled title="Phase 2">
+          <button class="nav-item" disabled aria-disabled="true" title="Phase 2">
             <span class="nav-icon" aria-hidden="true"><IconSettings /></span>
             <span class="nav-label">设置</span>
           </button>
-          <button class="nav-item" disabled title="Phase 2">
+          <button class="nav-item" disabled aria-disabled="true" title="Phase 2">
             <span class="nav-icon" aria-hidden="true"><IconHelp /></span>
             <span class="nav-label">帮助</span>
           </button>

--- a/packages/soft-dtu/webview/src/App.tsx
+++ b/packages/soft-dtu/webview/src/App.tsx
@@ -1,57 +1,164 @@
 /**
- * 软 DTU WebView 主组件 — Tab 路由
+ * 软 DTU WebView 主组件 — Sidebar + Header + Status bar 布局
+ *
+ * 布局（Apple SF dark mode）：
+ *   ┌─Sidebar(200px)─┐ ┌─Header(56px)────────────────────┐
+ *   │  透色 blur       │ │  软 DTU 控制台    [连接状态 pill]│
+ *   │  ⚙ 软 DTU        │ ├─────────────────────────────────┤
+ *   │  • 串口配置      │ │                                 │
+ *   │  • AT 指令       │ │  [Current panel content]        │
+ *   │  • HEX/ASCII     │ │   - 24px padding                │
+ *   │  • 协议定义      │ │   - 卡片化表单                  │
+ *   │  ⚙ 设置         │ │   - 表格 / 列表                 │
+ *   │  ? 帮助          │ │                                 │
+ *   └──────────────────┘ ├─Status bar(28px)────────────────┤
+ *                       │ Server URL · 2 protocols · 状态  │
+ *                       └─────────────────────────────────┘
  *
  * 4 个面板：
- *   1. SerialConfig  — 串口配置（选串口 + 波特率/数据位/停止位/校验）
- *   2. ATConsole    — AT 指令控制台（发 +++AT+XXX + 自动补全）
- *   3. HexView      — HEX/ASCII 实时数据视图
+ *   1. SerialConfig   — 串口配置（选串口 + 波特率/数据位/停止位/校验）
+ *   2. ATConsole      — AT 指令控制台（发 +++AT+XXX + 自动补全）
+ *   3. HexView        — HEX/ASCII 实时数据视图
  *   4. ProtocolViewer — 协议定义浏览器（手动选协议，看 AT 指令 + 寄存器表）
+ *
+ * Health check 走 /api/health（5s 轮询），protocol count 从 /api/protocols 拿。
  */
 
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { SerialConfig } from "./panels/SerialConfig.tsx";
 import { ATConsole } from "./panels/ATConsole.tsx";
 import { HexView } from "./panels/HexView.tsx";
 import { ProtocolViewer } from "./panels/ProtocolViewer.tsx";
 
 type Tab = "serial" | "at" | "hex" | "protocol";
+type Health = "connected" | "offline" | "error";
 
-const TABS: Array<{ id: Tab; label: string; hint: string }> = [
-  { id: "serial", label: "串口配置", hint: "选串口 + 波特率/数据位/停止位/校验" },
-  { id: "at", label: "AT 指令", hint: "发 +++AT+XXX + 自动补全" },
-  { id: "hex", label: "HEX/ASCII", hint: "实时数据流 HEX/ASCII 切换" },
-  { id: "protocol", label: "协议定义", hint: "从 server 拉的协议目录" },
+const NAV: Array<{ id: Tab; label: string; icon: string; hint: string }> = [
+  { id: "serial",   label: "串口配置", icon: "🔌", hint: "选择并打开设备的串口" },
+  { id: "at",       label: "AT 指令",  icon: "📡", hint: "跟软 DTU 收发 4G AT 指令" },
+  { id: "hex",      label: "HEX/ASCII", icon: "📊", hint: "实时数据流 HEX/ASCII 切换" },
+  { id: "protocol", label: "协议定义", icon: "📋", hint: "从 server 拉的协议目录" },
 ];
+
+const SERVER_URL = "https://uart.ladishb.com";
 
 export function App() {
   const [tab, setTab] = useState<Tab>("serial");
+  const [health, setHealth] = useState<Health>("offline");
+  const [protocolCount, setProtocolCount] = useState<number | null>(null);
+  const [now, setNow] = useState(Date.now());
+
+  // Health check 5s 轮询
+  useEffect(() => {
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const r = await fetch("/api/health", { cache: "no-store" });
+        if (!cancelled) setHealth(r.ok ? "connected" : "error");
+      } catch {
+        if (!cancelled) setHealth("offline");
+      }
+    };
+    check();
+    const t = setInterval(check, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  // Protocol count: 切到 protocol tab 时刷新, 其它时间后台静默
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/protocols")
+      .then((r) => r.json())
+      .then((d) => {
+        if (!cancelled) {
+          const n = Array.isArray(d?.protocols) ? d.protocols.length : 0;
+          setProtocolCount(n);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setProtocolCount(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tab]);
+
+  // 时钟（status bar 显示用）
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const current = NAV.find((n) => n.id === tab)!;
+  const healthLabel = health === "connected" ? "已连接" : health === "offline" ? "离线" : "异常";
 
   return (
     <div class="app">
-      <header class="app-header">
-        <h1>软 DTU 控制台</h1>
-        <span class="subtitle">UartNode · Deno Desktop · Phase 1</span>
-      </header>
-
-      <nav class="tabs">
-        {TABS.map((t) => (
-          <button
-            key={t.id}
-            class={`tab ${tab === t.id ? "active" : ""}`}
-            onClick={() => setTab(t.id)}
-            title={t.hint}
-          >
-            {t.label}
+      <aside class="sidebar" aria-label="主导航">
+        <div class="sidebar-brand">⚙ 软 DTU</div>
+        <nav class="sidebar-nav">
+          {NAV.map((n) => (
+            <button
+              key={n.id}
+              class={`nav-item ${tab === n.id ? "active" : ""}`}
+              onClick={() => setTab(n.id)}
+              title={n.hint}
+            >
+              <span class="nav-icon" aria-hidden="true">{n.icon}</span>
+              <span class="nav-label">{n.label}</span>
+            </button>
+          ))}
+        </nav>
+        <div class="sidebar-footer">
+          <button class="nav-item" disabled title="Phase 2">
+            <span class="nav-icon" aria-hidden="true">⚙</span>
+            <span class="nav-label">设置</span>
           </button>
-        ))}
-      </nav>
+          <button class="nav-item" disabled title="Phase 2">
+            <span class="nav-icon" aria-hidden="true">?</span>
+            <span class="nav-label">帮助</span>
+          </button>
+        </div>
+      </aside>
 
-      <main class="panel">
-        {tab === "serial" && <SerialConfig />}
-        {tab === "at" && <ATConsole />}
-        {tab === "hex" && <HexView />}
-        {tab === "protocol" && <ProtocolViewer />}
-      </main>
+      <div class="main">
+        <header class="app-header">
+          <div class="header-text">
+            <h1 class="header-title">{current.label}</h1>
+            <p class="header-subtitle">{current.hint}</p>
+          </div>
+          <span class={`status-pill ${health}`} title={`Server: ${SERVER_URL}`}>
+            {healthLabel}
+          </span>
+        </header>
+
+        <main class="panel" key={tab}>
+          {tab === "serial"   && <SerialConfig />}
+          {tab === "at"       && <ATConsole />}
+          {tab === "hex"      && <HexView />}
+          {tab === "protocol" && <ProtocolViewer />}
+        </main>
+
+        <footer class="status-bar">
+          <span>
+            <span class={`indicator ${health}`}></span>
+            {healthLabel}
+          </span>
+          <span class="sep">·</span>
+          <span>Server: {SERVER_URL}</span>
+          <span class="sep">·</span>
+          <span>
+            {protocolCount !== null ? `${protocolCount} protocols` : "— protocols"}
+          </span>
+          <span class="spacer"></span>
+          <span>UartNode · Deno Desktop · Phase 1</span>
+          <span class="sep">·</span>
+          <span>{new Date(now).toLocaleTimeString("zh-CN", { hour12: false })}</span>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/packages/soft-dtu/webview/src/App.tsx
+++ b/packages/soft-dtu/webview/src/App.tsx
@@ -5,39 +5,70 @@
  *   ┌─Sidebar(200px)─┐ ┌─Header(56px)────────────────────┐
  *   │  透色 blur       │ │  软 DTU 控制台    [连接状态 pill]│
  *   │  ⚙ 软 DTU        │ ├─────────────────────────────────┤
- *   │  • 串口配置      │ │                                 │
- *   │  • AT 指令       │ │  [Current panel content]        │
- *   │  • HEX/ASCII     │ │   - 24px padding                │
- *   │  • 协议定义      │ │   - 卡片化表单                  │
- *   │  ⚙ 设置         │ │   - 表格 / 列表                 │
+ *   │  • 串口配置 ⌘1   │ │                                 │
+ *   │  • AT 指令  ⌘2   │ │  [Current panel content]        │
+ *   │  • HEX/ASCII⌘3   │ │   - 24px padding                │
+ *   │  • 协议定义 ⌘4   │ │   - 卡片化表单                  │
+ *   │  ⚙ 设置          │ │   - 表格 / 列表                  │
  *   │  ? 帮助          │ │                                 │
  *   └──────────────────┘ ├─Status bar(28px)────────────────┤
- *                       │ Server URL · 2 protocols · 状态  │
+ *                       │ Server URL · protocols · last sync│
  *                       └─────────────────────────────────┘
  *
  * 4 个面板：
  *   1. SerialConfig   — 串口配置（选串口 + 波特率/数据位/停止位/校验）
- *   2. ATConsole      — AT 指令控制台（发 +++AT+XXX + 自动补全）
- *   3. HexView        — HEX/ASCII 实时数据视图
- *   4. ProtocolViewer — 协议定义浏览器（手动选协议，看 AT 指令 + 寄存器表）
+ *   2. ATConsole      — AT 指令控制台（发 +++AT+XXX + 自动补全 + 历史 + Tab）
+ *   3. HexView        — HEX/ASCII 实时数据视图（三栏 16B/行）
+ *   4. ProtocolViewer — 协议定义浏览器（empty state + meta-grid + AT 表 + 寄存器表）
+ *
+ * 接力补的 12 项细化（在 cronId 02760e66 worker 基础上）：
+ *   1. SVG icons (替换 emoji) — src/icons.tsx
+ *   2. Status pill pulse 动画 — status-pill.connected::before animation
+ *   3. Focus ring (button/input) — :focus-visible outline
+ *   4. Empty state 组件 — src/components/EmptyState.tsx
+ *   5. Error banner (icon + dismiss) — src/components/ErrorBanner.tsx
+ *   6. Toast (右下角, 3s 消失) — src/components/Toast.tsx
+ *   7. Keyboard shortcut (Cmd+1/2/3/4) — 本文件 useEffect
+ *   8. AT console history (↑↓) + Cmd+Enter + Clear log + auto-scroll
+ *   9. HEX view 三栏对齐 (offset/hex/ascii, 16B/行) — HexView.tsx
+ *  10. ProtocolViewer meta-grid SF card 风格 — ProtocolViewer.tsx
+ *  11. Status bar "last sync" 指示 — 本文件 + Health check 5s 轮询
+ *  12. Segmented control pill SF 风格 — styles.css .seg 微调
  *
  * Health check 走 /api/health（5s 轮询），protocol count 从 /api/protocols 拿。
+ * last sync: health 200 时更新时间, 显示"已同步 HH:MM:SS" / "从未同步"。
  */
 
 import { useEffect, useState } from "preact/hooks";
+import type { JSX } from "preact";
 import { SerialConfig } from "./panels/SerialConfig.tsx";
 import { ATConsole } from "./panels/ATConsole.tsx";
 import { HexView } from "./panels/HexView.tsx";
 import { ProtocolViewer } from "./panels/ProtocolViewer.tsx";
+import {
+  IconSerial,
+  IconAT,
+  IconHex,
+  IconProtocol,
+  IconSettings,
+  IconHelp,
+} from "./icons.tsx";
+import { ToastStack, useToasts } from "./components/Toast.tsx";
 
 type Tab = "serial" | "at" | "hex" | "protocol";
 type Health = "connected" | "offline" | "error";
 
-const NAV: Array<{ id: Tab; label: string; icon: string; hint: string }> = [
-  { id: "serial",   label: "串口配置", icon: "🔌", hint: "选择并打开设备的串口" },
-  { id: "at",       label: "AT 指令",  icon: "📡", hint: "跟软 DTU 收发 4G AT 指令" },
-  { id: "hex",      label: "HEX/ASCII", icon: "📊", hint: "实时数据流 HEX/ASCII 切换" },
-  { id: "protocol", label: "协议定义", icon: "📋", hint: "从 server 拉的协议目录" },
+const NAV: Array<{
+  id: Tab;
+  label: string;
+  Icon: () => JSX.Element;
+  hint: string;
+  shortcut: string;
+}> = [
+  { id: "serial",   label: "串口配置", Icon: IconSerial,   hint: "选择并打开设备的串口",  shortcut: "⌘1" },
+  { id: "at",       label: "AT 指令",  Icon: IconAT,       hint: "跟软 DTU 收发 4G AT 指令", shortcut: "⌘2" },
+  { id: "hex",      label: "HEX/ASCII", Icon: IconHex,     hint: "实时数据流 HEX/ASCII 切换", shortcut: "⌘3" },
+  { id: "protocol", label: "协议定义", Icon: IconProtocol, hint: "从 server 拉的协议目录",  shortcut: "⌘4" },
 ];
 
 const SERVER_URL = "https://uart.ladishb.com";
@@ -47,14 +78,23 @@ export function App() {
   const [health, setHealth] = useState<Health>("offline");
   const [protocolCount, setProtocolCount] = useState<number | null>(null);
   const [now, setNow] = useState(Date.now());
+  const [lastSync, setLastSync] = useState<Date | null>(null);
+  const { toasts, push } = useToasts();
 
-  // Health check 5s 轮询
+  // Health check 5s 轮询 — 成功时更新 lastSync
   useEffect(() => {
     let cancelled = false;
     const check = async () => {
       try {
         const r = await fetch("/api/health", { cache: "no-store" });
-        if (!cancelled) setHealth(r.ok ? "connected" : "error");
+        if (!cancelled) {
+          if (r.ok) {
+            setHealth("connected");
+            setLastSync(new Date());
+          } else {
+            setHealth("error");
+          }
+        }
       } catch {
         if (!cancelled) setHealth("offline");
       }
@@ -92,33 +132,72 @@ export function App() {
     return () => clearInterval(t);
   }, []);
 
+  // 键盘快捷键: Cmd+1/2/3/4 切面板
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && ["1", "2", "3", "4"].includes(e.key)) {
+        e.preventDefault();
+        const idx = parseInt(e.key, 10) - 1;
+        const next = NAV[idx]?.id;
+        if (next && next !== tab) {
+          setTab(next);
+          push({ text: `切换到 ${NAV[idx].label}`, duration: 1800 });
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [tab, push]);
+
   const current = NAV.find((n) => n.id === tab)!;
   const healthLabel = health === "connected" ? "已连接" : health === "offline" ? "离线" : "异常";
+
+  // last sync 文案 + freshness 状态
+  const lastSyncClass = !lastSync
+    ? "never"
+    : Date.now() - lastSync.getTime() < 30_000
+    ? "fresh"
+    : "";
+  const lastSyncText = !lastSync
+    ? "从未同步"
+    : `已同步 ${lastSync.toLocaleTimeString("zh-CN", { hour12: false })}`;
 
   return (
     <div class="app">
       <aside class="sidebar" aria-label="主导航">
-        <div class="sidebar-brand">⚙ 软 DTU</div>
+        <div class="sidebar-brand">
+          <span class="sidebar-brand-mark" aria-hidden="true">
+            <IconSettings />
+          </span>
+          <span>软 DTU</span>
+        </div>
         <nav class="sidebar-nav">
-          {NAV.map((n) => (
-            <button
-              key={n.id}
-              class={`nav-item ${tab === n.id ? "active" : ""}`}
-              onClick={() => setTab(n.id)}
-              title={n.hint}
-            >
-              <span class="nav-icon" aria-hidden="true">{n.icon}</span>
-              <span class="nav-label">{n.label}</span>
-            </button>
-          ))}
+          {NAV.map((n) => {
+            const Icon = n.Icon;
+            return (
+              <button
+                key={n.id}
+                class={`nav-item ${tab === n.id ? "active" : ""}`}
+                onClick={() => setTab(n.id)}
+                title={n.hint}
+                aria-current={tab === n.id ? "page" : undefined}
+              >
+                <span class="nav-icon" aria-hidden="true"><Icon /></span>
+                <span class="nav-label">{n.label}</span>
+                <span class="nav-shortcut" aria-label={`快捷键 ${n.shortcut}`}>
+                  {n.shortcut}
+                </span>
+              </button>
+            );
+          })}
         </nav>
         <div class="sidebar-footer">
           <button class="nav-item" disabled title="Phase 2">
-            <span class="nav-icon" aria-hidden="true">⚙</span>
+            <span class="nav-icon" aria-hidden="true"><IconSettings /></span>
             <span class="nav-label">设置</span>
           </button>
           <button class="nav-item" disabled title="Phase 2">
-            <span class="nav-icon" aria-hidden="true">?</span>
+            <span class="nav-icon" aria-hidden="true"><IconHelp /></span>
             <span class="nav-label">帮助</span>
           </button>
         </div>
@@ -136,8 +215,8 @@ export function App() {
         </header>
 
         <main class="panel" key={tab}>
-          {tab === "serial"   && <SerialConfig />}
-          {tab === "at"       && <ATConsole />}
+          {tab === "serial"   && <SerialConfig onSuccess={(msg) => push({ text: msg })} />}
+          {tab === "at"       && <ATConsole onSuccess={(msg) => push({ text: msg })} />}
           {tab === "hex"      && <HexView />}
           {tab === "protocol" && <ProtocolViewer />}
         </main>
@@ -154,11 +233,15 @@ export function App() {
             {protocolCount !== null ? `${protocolCount} protocols` : "— protocols"}
           </span>
           <span class="spacer"></span>
+          <span class={`last-sync ${lastSyncClass}`}>{lastSyncText}</span>
+          <span class="sep">·</span>
           <span>UartNode · Deno Desktop · Phase 1</span>
           <span class="sep">·</span>
           <span>{new Date(now).toLocaleTimeString("zh-CN", { hour12: false })}</span>
         </footer>
       </div>
+
+      <ToastStack toasts={toasts} />
     </div>
   );
 }

--- a/packages/soft-dtu/webview/src/api.ts
+++ b/packages/soft-dtu/webview/src/api.ts
@@ -1,0 +1,187 @@
+/**
+ * HTTP API wrapper — 软 DTU WebView → Deno 后端
+ *
+ * Phase 1 走 fetch (Vite dev server proxy /api/* → Deno serve on 127.0.0.1:8080)
+ * Phase 2 切 Deno Desktop bindings SDK（直接 IPC，无 HTTP）
+ *
+ * 端点：
+ *   - GET  /api/serial/list          → SerialPortInfo[]
+ *   - POST /api/serial/open          → { path, options }
+ *   - POST /api/serial/close         → void
+ *   - POST /api/serial/write         → { data: string (utf8) | base64 }
+ *   - GET  /api/serial/status        → { isOpen, currentPort }
+ *   - GET  /api/serial/stream        → SSE (data/error/close 事件)
+ *   - GET  /api/protocols            → ProtocolDefinition[]
+ *   - GET  /api/protocols/refresh    → ProtocolDefinition[] (强制刷新)
+ *
+ * ⚠️ 字段名必须跟 Deno 端 src/bindings/serial.ts + protocol.ts 1:1
+ */
+
+import type {
+  SerialBindings,
+  ProtocolBindings,
+  SerialPortInfo,
+  SerialOptions,
+  CurrentPort,
+  ProtocolDefinition,
+} from "./bindings.ts";
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
+
+class HttpError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown, message: string) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function http<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      body = await res.text();
+    }
+    throw new HttpError(res.status, body, `${init?.method ?? "GET"} ${path} → ${res.status}`);
+  }
+  const ct = res.headers.get("content-type") ?? "";
+  if (ct.includes("application/json")) {
+    return (await res.json()) as T;
+  }
+  return (await res.text()) as unknown as T;
+}
+
+/** Uint8Array → base64 (写串口用) */
+function uint8ToBase64(arr: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < arr.length; i++) bin += String.fromCharCode(arr[i]);
+  return btoa(bin);
+}
+
+/** Uint8Array → hex 字符串 (HEX 视图用) */
+export function uint8ToHex(arr: Uint8Array): string {
+  return Array.from(arr)
+    .map((b) => b.toString(16).padStart(2, "0").toUpperCase())
+    .join(" ");
+}
+
+export const serial: SerialBindings = {
+  async list(): Promise<SerialPortInfo[]> {
+    return http<SerialPortInfo[]>("/serial/list");
+  },
+
+  async open(path: string, options: SerialOptions): Promise<void> {
+    await http<void>("/serial/open", {
+      method: "POST",
+      body: JSON.stringify({ path, options }),
+    });
+  },
+
+  async close(): Promise<void> {
+    await http<void>("/serial/close", { method: "POST" });
+  },
+
+  async write(data: string | Uint8Array): Promise<void> {
+    const payload = typeof data === "string" ? { data } : { data: uint8ToBase64(data) };
+    await http<void>("/serial/write", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+
+  isOpen(): boolean {
+    // 同步读不到后端状态 — UI 拿 status 后再判断
+    // 这里给 false 让 UI 必须先调 status
+    return false;
+  },
+
+  currentPort(): CurrentPort | null {
+    return null;
+  },
+
+  onData(handler: (data: Uint8Array) => void): () => void {
+    // Phase 1: 用 EventSource (SSE) 订阅数据流
+    const es = new EventSource(`${API_BASE}/serial/stream?channel=data`);
+    const onMsg = (ev: MessageEvent) => {
+      try {
+        // SSE payload: { bytes: base64 }
+        const payload = JSON.parse(ev.data) as { bytes: string };
+        const bin = atob(payload.bytes);
+        const arr = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+        handler(arr);
+      } catch (err) {
+        console.warn("[api.serial] bad data event:", err);
+      }
+    };
+    es.addEventListener("data", onMsg as EventListener);
+    es.onerror = (err) => {
+      console.warn("[api.serial] SSE error:", err);
+    };
+    return () => es.close();
+  },
+
+  onError(handler: (err: Error) => void): () => void {
+    const es = new EventSource(`${API_BASE}/serial/stream?channel=error`);
+    const onMsg = (ev: MessageEvent) => {
+      try {
+        const payload = JSON.parse(ev.data) as { message: string };
+        handler(new Error(payload.message));
+      } catch (err) {
+        handler(err as Error);
+      }
+    };
+    es.addEventListener("error", onMsg as EventListener);
+    return () => es.close();
+  },
+
+  onClose(handler: () => void): () => void {
+    const es = new EventSource(`${API_BASE}/serial/stream?channel=close`);
+    es.addEventListener("close", handler as EventListener);
+    return () => es.close();
+  },
+};
+
+export const protocol: ProtocolBindings = {
+  async list(): Promise<ProtocolDefinition[]> {
+    const res = await http<{ protocols: ProtocolDefinition[] }>("/protocols");
+    return res.protocols;
+  },
+
+  get(id: string): ProtocolDefinition | undefined {
+    // HTTP 不能同步读 — 改成异步缓存（组件用 useProtocols() hook 拿）
+    void id;
+    return undefined;
+  },
+
+  async refresh(): Promise<ProtocolDefinition[]> {
+    const res = await http<{ protocols: ProtocolDefinition[] }>("/protocols/refresh");
+    return res.protocols;
+  },
+
+  isOffline(): boolean {
+    return false; // 异步状态，组件用 useProtocols() hook 拿
+  },
+
+  onUpdate(_handler: (protocols: ProtocolDefinition[]) => void): () => void {
+    // Phase 1 不实现 push，等 Phase 2 Deno Desktop bindings
+    return () => {};
+  },
+};
+
+export async function getSerialStatus(): Promise<{ isOpen: boolean; currentPort: CurrentPort | null }> {
+  return http<{ isOpen: boolean; currentPort: CurrentPort | null }>("/serial/status");
+}
+
+export { HttpError };

--- a/packages/soft-dtu/webview/src/api.ts
+++ b/packages/soft-dtu/webview/src/api.ts
@@ -93,7 +93,11 @@ export const serial: SerialBindings = {
   },
 
   async write(data: string | Uint8Array): Promise<void> {
-    const payload = typeof data === "string" ? { data } : { data: uint8ToBase64(data) };
+    // I4: 显式 encoding — 跟 Deno 端 http-api.ts:write 同步
+    // 之前启发式猜 base64 会把 4 字符 ASCII ("ATEN"/"INFO"/"1234") 误判成 base64
+    const payload = typeof data === "string"
+      ? { data, encoding: "utf8" }
+      : { data: uint8ToBase64(data), encoding: "base64" };
     await http<void>("/serial/write", {
       method: "POST",
       body: JSON.stringify(payload),

--- a/packages/soft-dtu/webview/src/bindings.ts
+++ b/packages/soft-dtu/webview/src/bindings.ts
@@ -1,0 +1,101 @@
+/**
+ * 软 DTU WebView bindings 类型契约
+ *
+ * 必须 1:1 跟 Deno 端 `packages/soft-dtu/src/bindings/serial.ts` 和
+ * `packages/soft-dtu/src/bindings/protocol.ts` 保持一致。
+ *
+ * Phase 1 走 HTTP（前端 fetch /api/* → Deno main.ts 启 deno serve 包装 bindings）
+ * Phase 2 切 Deno Desktop official bindings SDK（window.bindings.* 直接 IPC）
+ *
+ * ⚠️ 改这里之前先看 server-api-contract.md 和 AGENTS.md 字段名约定：
+ * 跨 worker 字段错位会**静默失败**（HTTP 拉不到 → 走 offline fallback → UI 缺协议）。
+ */
+
+export interface SerialPortInfo {
+  path: string;
+  manufacturer?: string;
+  productId?: string;
+  vendorId?: string;
+}
+
+export interface SerialOptions {
+  baudRate: number;
+  dataBits?: 5 | 6 | 7 | 8;
+  stopBits?: 1 | 2;
+  parity?: "none" | "even" | "odd" | "mark" | "space";
+  lock?: boolean;
+}
+
+export interface CurrentPort {
+  path: string;
+  options: SerialOptions;
+}
+
+export interface AtCommandDefinition {
+  name: string;
+  cmd: string;
+  parse: string;
+  description?: string;
+}
+
+export interface RegisterDefinition {
+  format: string;
+  imeiLength: number;
+  triggerOnInvite: boolean;
+}
+
+export interface ModbusRegister {
+  address: number;
+  name: string;
+  type: "coil" | "discrete" | "holding" | "input";
+  dataType: "uint16" | "int16" | "uint32" | "int32" | "float" | "double";
+  unit?: string;
+  scale?: number;
+  description?: string;
+}
+
+export interface ProtocolDefinition {
+  id: string;
+  name: string;
+  type: "cellular-4g-dtu" | "modbus-rtu" | "lan-gateway" | "uart-direct";
+  manufacturer?: string;
+  model?: string;
+  category?: string;
+  version?: string;
+  metadata?: Record<string, string>;
+  atCommands?: AtCommandDefinition[];
+  registers?: ModbusRegister[];
+  register?: RegisterDefinition;
+  defaultSerial?: {
+    baudRate: number;
+    dataBits: 5 | 6 | 7 | 8;
+    stopBits: 1 | 2;
+    parity: "none" | "even" | "odd" | "mark" | "space";
+  };
+  transport?: "tcp:9000" | "serial" | "tcp:custom";
+}
+
+export interface SerialBindings {
+  list(): Promise<SerialPortInfo[]>;
+  open(path: string, options: SerialOptions): Promise<void>;
+  close(): Promise<void>;
+  write(data: string | Uint8Array): Promise<void>;
+  isOpen(): boolean;
+  currentPort(): CurrentPort | null;
+  onData(handler: (data: Uint8Array) => void): () => void;
+  onError(handler: (err: Error) => void): () => void;
+  onClose(handler: () => void): () => void;
+}
+
+export interface ProtocolBindings {
+  list(): Promise<ProtocolDefinition[]>;
+  get(id: string): ProtocolDefinition | undefined;
+  refresh(): Promise<ProtocolDefinition[]>;
+  isOffline(): boolean;
+  onUpdate(handler: (protocols: ProtocolDefinition[]) => void): () => void;
+}
+
+export interface SoftDtuBindings {
+  serial: SerialBindings;
+  protocol: ProtocolBindings;
+}

--- a/packages/soft-dtu/webview/src/components/EmptyState.tsx
+++ b/packages/soft-dtu/webview/src/components/EmptyState.tsx
@@ -1,0 +1,38 @@
+/**
+ * Empty state 组件 — Apple SF 风格空状态
+ *
+ * 用法:
+ *   <EmptyState
+ *     icon={<IconProtocol />}
+ *     title="选择一个协议"
+ *     hint="从上方下拉菜单选择软 DTU 协议, 查看 AT 指令和寄存器表"
+ *   />
+ *
+ * 视觉:
+ *   - 56px 灰色 icon, opacity 0.7
+ *   - 17px semi-bold 标题
+ *   - 13px secondary hint, max-width 360px
+ *   - 80px 上下 padding, 居中
+ */
+
+import type { ComponentChildren, JSX } from "preact";
+
+export interface EmptyStateProps {
+  icon: JSX.Element;
+  title: string;
+  hint: string;
+  action?: ComponentChildren;
+}
+
+export function EmptyState(
+  { icon, title, hint, action }: EmptyStateProps,
+): JSX.Element {
+  return (
+    <div class="empty-state" role="status">
+      <div class="empty-state-icon" aria-hidden="true">{icon}</div>
+      <h3 class="empty-state-title">{title}</h3>
+      <p class="empty-state-hint">{hint}</p>
+      {action && <div class="empty-state-action">{action}</div>}
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/components/ErrorBanner.tsx
+++ b/packages/soft-dtu/webview/src/components/ErrorBanner.tsx
@@ -6,12 +6,12 @@
  *
  * 比前 worker 的 .error (仅文字 + 边框) 多:
  *   - inline error icon (16x16 SVG)
- *   - dismiss × 按钮 (右对齐, hover 加深)
+ *   - dismiss × 按钮 (右对齐, hover 加深) — v2 改 IconClose SVG 替代文字
  *   - 入场动画 (translateY -4px + opacity)
  */
 
 import type { ComponentChildren, JSX } from "preact";
-import { IconError } from "../icons.tsx";
+import { IconError, IconClose } from "../icons.tsx";
 
 export interface ErrorBannerProps {
   onDismiss: () => void;
@@ -35,7 +35,7 @@ export function ErrorBanner(
         onClick={onDismiss}
         aria-label="关闭错误提示"
       >
-        ×
+        <IconClose />
       </button>
     </div>
   );

--- a/packages/soft-dtu/webview/src/components/ErrorBanner.tsx
+++ b/packages/soft-dtu/webview/src/components/ErrorBanner.tsx
@@ -1,0 +1,42 @@
+/**
+ * Error banner — 红色 12% bg + 1px border + dismiss 按钮
+ *
+ * 用法:
+ *   {error && <ErrorBanner onDismiss={() => setError(null)}>{error}</ErrorBanner>}
+ *
+ * 比前 worker 的 .error (仅文字 + 边框) 多:
+ *   - inline error icon (16x16 SVG)
+ *   - dismiss × 按钮 (右对齐, hover 加深)
+ *   - 入场动画 (translateY -4px + opacity)
+ */
+
+import type { ComponentChildren, JSX } from "preact";
+import { IconError } from "../icons.tsx";
+
+export interface ErrorBannerProps {
+  onDismiss: () => void;
+  children: ComponentChildren;
+  /** aria-live 默认 "assertive"（error 重要） */
+  ariaLive?: "polite" | "assertive";
+}
+
+export function ErrorBanner(
+  { onDismiss, children, ariaLive = "assertive" }: ErrorBannerProps,
+): JSX.Element {
+  return (
+    <div class="error-banner" role="alert" aria-live={ariaLive}>
+      <span class="error-banner-icon" aria-hidden="true">
+        <IconError />
+      </span>
+      <span class="error-banner-text">{children}</span>
+      <button
+        type="button"
+        class="error-banner-dismiss"
+        onClick={onDismiss}
+        aria-label="关闭错误提示"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/components/Toast.tsx
+++ b/packages/soft-dtu/webview/src/components/Toast.tsx
@@ -1,0 +1,99 @@
+/**
+ * Toast / Snackbar — 右下角浮层, 3s 自动消失, materialize animation
+ *
+ * 用法:
+ *   const { toasts, push } = useToasts();
+ *   push({ text: "串口已打开", duration: 3000 });
+ *
+ *   <ToastStack toasts={toasts} />
+ *
+ * 视觉:
+ *   - rgba(58,58,60,0.95) + blur(20px) saturate(180%) 毛玻璃
+ *   - 16x16 check icon (绿色) + 13px 文字
+ *   - bottom 44px, right 24px (避开 status bar 28px)
+ *   - 入场 scale(0.96) + opacity 0→1, 出场反向
+ *   - 多 toast 堆叠 (column flex, 8px gap)
+ *
+ * 可访问性:
+ *   - role="status" aria-live="polite" (不像 error 要 assert)
+ *   - 鼠标 hover 不消失 (用 duration 截止时间戳判断)
+ */
+
+import type { JSX } from "preact";
+import { useEffect, useState, useCallback, useRef } from "preact/hooks";
+import { IconCheck } from "../icons.tsx";
+
+export interface ToastItem {
+  id: number;
+  text: string;
+  /** 自动消失时长 (ms), 默认 3000 */
+  duration: number;
+  /** 创建时间戳 (ms) — 内部用 */
+  createdAt: number;
+  /** 正在淡出 (内部用) */
+  fading?: boolean;
+}
+
+let _toastIdSeq = 0;
+
+export function useToasts() {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, fading: true } : t))
+    );
+    // 200ms 出场动画后真正移除
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 220);
+  }, []);
+
+  const push = useCallback((opts: { text: string; duration?: number }) => {
+    const id = ++_toastIdSeq;
+    const item: ToastItem = {
+      id,
+      text: opts.text,
+      duration: opts.duration ?? 3000,
+      createdAt: Date.now(),
+    };
+    setToasts((prev) => [...prev, item]);
+    const t = setTimeout(() => dismiss(id), item.duration);
+    timers.current.set(id, t);
+    return id;
+  }, [dismiss]);
+
+  useEffect(() => {
+    return () => {
+      for (const t of timers.current.values()) clearTimeout(t);
+      timers.current.clear();
+    };
+  }, []);
+
+  return { toasts, push, dismiss };
+}
+
+export interface ToastStackProps {
+  toasts: ToastItem[];
+}
+
+export function ToastStack({ toasts }: ToastStackProps): JSX.Element | null {
+  if (toasts.length === 0) return null;
+  return (
+    <div class="toast-stack" aria-live="polite" aria-atomic="false">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          class={`toast ${t.fading ? "toast-out" : ""}`}
+          role="status"
+        >
+          <span class="toast-icon" aria-hidden="true">
+            <IconCheck />
+          </span>
+          <span class="toast-text">{t.text}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/icons.tsx
+++ b/packages/soft-dtu/webview/src/icons.tsx
@@ -1,12 +1,15 @@
 /**
- * Inline SVG icons — Apple SF Symbols 风格 (1.5px stroke, 20x20 viewBox)
+ * Inline SVG icons — Apple SF Symbols 风格 (1.75px stroke, 20x20 viewBox)
  *
- * 用 currentColor 让父级 color 控制（sidebar active 蓝色, 平时 secondary）
- * 18-20px 大小, stroke 1.5px, linecap/linejoin round（跟 SF 一致）
+ * 用 currentColor 让父级 color 控制（sidebar active 暖橙, 平时 secondary）
+ * 22-26px 容器, stroke 1.75px, linecap/linejoin round（跟 SF 一致, 加粗增强可见性）
  *
  * 用法:
- *   <IconSerial />  — sidebar nav icon
+ *   <IconSerial />                  — sidebar nav icon (22px 容器)
  *   <span class="nav-icon"><IconSerial /></span>
+ *
+ * v2 接力: 加 9 个新 icon (Logo/Refresh/Send/Close/Trash/Play/Pause/Copy/Warning/Info),
+ * stroke 1.5 → 1.75px 增强可见性, 配套新暖橙调色板.
  *
  * 跟前 worker 用的 emoji 替换（"🔌📡📊📋"）.
  * 理由: emoji 字体在 macOS/Windows/Linux 渲染不一致, 颜色用不了,
@@ -19,7 +22,7 @@ const base = {
   viewBox: "0 0 20 20",
   fill: "none",
   stroke: "currentColor",
-  "stroke-width": 1.5,
+  "stroke-width": 1.75,
   "stroke-linecap": "round",
   "stroke-linejoin": "round",
   "aria-hidden": "true",
@@ -100,8 +103,119 @@ export function IconError(): JSX.Element {
 
 export function IconCheck(): JSX.Element {
   return (
-    <svg {...base} stroke-width="2">
+    <svg {...base} stroke-width="2.25">
       <path d="M4 10 L8 14 L16 6" />
+    </svg>
+  );
+}
+
+/* ─── v2 接力: 9 个新 icon (cairui 反馈) ─── */
+
+/** 品牌 logo: 节点 + 4 圈 radio wave (软 DTU 模块意象) */
+export function IconLogo(): JSX.Element {
+  return (
+    <svg {...base}>
+      <circle cx="10" cy="10" r="1.5" fill="currentColor" stroke="none" />
+      <path d="M7 7 a4.24 4.24 0 0 1 6 0" />
+      <path d="M13 13 a4.24 4.24 0 0 1 -6 0" />
+      <path d="M4.5 4.5 a7.78 7.78 0 0 1 11 0" />
+      <path d="M15.5 15.5 a7.78 7.78 0 0 1 -11 0" />
+    </svg>
+  );
+}
+
+/** 强制刷新 — 圆弧 + 末端箭头 */
+export function IconRefresh(): JSX.Element {
+  return (
+    <svg {...base}>
+      <path d="M3.5 10 a6.5 6.5 0 0 1 11.5 -4" />
+      <path d="M16.5 10 a6.5 6.5 0 0 1 -11.5 4" />
+      <polyline points="15 2 15 6 11 6" />
+      <polyline points="5 18 5 14 9 14" />
+    </svg>
+  );
+}
+
+/** 发送 — 纸飞机 */
+export function IconSend(): JSX.Element {
+  return (
+    <svg {...base}>
+      <path d="M2.5 10 L17.5 3 L13 17.5 L10 11 Z" />
+      <path d="M10 11 L17.5 3" />
+    </svg>
+  );
+}
+
+/** 关闭 — × 形 */
+export function IconClose(): JSX.Element {
+  return (
+    <svg {...base}>
+      <line x1="5" y1="5" x2="15" y2="15" />
+      <line x1="15" y1="5" x2="5" y2="15" />
+    </svg>
+  );
+}
+
+/** 清空 — 垃圾桶 */
+export function IconTrash(): JSX.Element {
+  return (
+    <svg {...base}>
+      <line x1="3" y1="6" x2="17" y2="6" />
+      <path d="M8 6 V4 a1 1 0 0 1 1 -1 h2 a1 1 0 0 1 1 1 V6" />
+      <path d="M5 6 l1 11 a1 1 0 0 0 1 1 h6 a1 1 0 0 0 1 -1 l1 -11" />
+      <line x1="9" y1="9" x2="9" y2="15" />
+      <line x1="11" y1="9" x2="11" y2="15" />
+    </svg>
+  );
+}
+
+/** 播放 — 实心三角 (streaming 启动) */
+export function IconPlay(): JSX.Element {
+  return (
+    <svg {...base} fill="currentColor" stroke="none">
+      <path d="M6 4 L16 10 L6 16 Z" />
+    </svg>
+  );
+}
+
+/** 暂停 — 双竖条 (streaming 暂停) */
+export function IconPause(): JSX.Element {
+  return (
+    <svg {...base} fill="currentColor" stroke="none">
+      <rect x="5" y="4" width="3.5" height="12" rx="0.75" />
+      <rect x="11.5" y="4" width="3.5" height="12" rx="0.75" />
+    </svg>
+  );
+}
+
+/** 复制 — 双叠方块 */
+export function IconCopy(): JSX.Element {
+  return (
+    <svg {...base}>
+      <rect x="7" y="7" width="11" height="11" rx="1.5" />
+      <path d="M14 7 V4 a1 1 0 0 0 -1 -1 H4 a1 1 0 0 0 -1 1 v9 a1 1 0 0 0 1 1 h3" />
+    </svg>
+  );
+}
+
+/** 警告 — 三角 + 叹号 */
+export function IconWarning(): JSX.Element {
+  return (
+    <svg {...base}>
+      <path d="M10 2.5 L18 17.5 H2 Z" />
+      <line x1="10" y1="8" x2="10" y2="12.5" />
+      <circle cx="10" cy="15" r="0.6" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+/** 信息 — 蓝 i 圆 */
+export function IconInfo(): JSX.Element {
+  return (
+    <svg {...base}>
+      <circle cx="10" cy="10" r="7.5" />
+      <line x1="10" y1="9.5" x2="10" y2="14" />
+      <circle cx="10" cy="6.75" r="0.6" fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/packages/soft-dtu/webview/src/icons.tsx
+++ b/packages/soft-dtu/webview/src/icons.tsx
@@ -1,0 +1,107 @@
+/**
+ * Inline SVG icons — Apple SF Symbols 风格 (1.5px stroke, 20x20 viewBox)
+ *
+ * 用 currentColor 让父级 color 控制（sidebar active 蓝色, 平时 secondary）
+ * 18-20px 大小, stroke 1.5px, linecap/linejoin round（跟 SF 一致）
+ *
+ * 用法:
+ *   <IconSerial />  — sidebar nav icon
+ *   <span class="nav-icon"><IconSerial /></span>
+ *
+ * 跟前 worker 用的 emoji 替换（"🔌📡📊📋"）.
+ * 理由: emoji 字体在 macOS/Windows/Linux 渲染不一致, 颜色用不了,
+ * Apple 风格 sidebar 不混 emoji.
+ */
+
+import type { JSX } from "preact";
+
+const base = {
+  viewBox: "0 0 20 20",
+  fill: "none",
+  stroke: "currentColor",
+  "stroke-width": 1.5,
+  "stroke-linecap": "round",
+  "stroke-linejoin": "round",
+  "aria-hidden": "true",
+} as const;
+
+export function IconSerial(): JSX.Element {
+  return (
+    <svg {...base}>
+      <rect x="3" y="6" width="14" height="8" rx="1.5" />
+      <line x1="3" y1="9" x2="17" y2="9" />
+      <line x1="3" y1="12" x2="17" y2="12" />
+      <circle cx="6" cy="7.5" r="0.5" fill="currentColor" />
+      <circle cx="6" cy="13.5" r="0.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function IconAT(): JSX.Element {
+  return (
+    <svg {...base}>
+      <path d="M2 10 L7 10 M5 7 L7 10 L5 13" />
+      <path d="M9 10 H15" />
+      <circle cx="17" cy="10" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function IconHex(): JSX.Element {
+  return (
+    <svg {...base}>
+      <rect x="3" y="3" width="6" height="6" rx="1" />
+      <rect x="11" y="3" width="6" height="6" rx="1" />
+      <rect x="3" y="11" width="6" height="6" rx="1" />
+      <rect x="11" y="11" width="6" height="6" rx="1" />
+    </svg>
+  );
+}
+
+export function IconProtocol(): JSX.Element {
+  return (
+    <svg {...base}>
+      <path d="M5 4 H13 a2 2 0 0 1 2 2 v8 a2 2 0 0 1 -2 2 H7 a2 2 0 0 1 -2 -2 v-2" />
+      <path d="M5 8 a2 2 0 0 1 2 -2 H13" />
+      <line x1="8" y1="11" x2="12" y2="11" />
+      <line x1="8" y1="14" x2="11" y2="14" />
+    </svg>
+  );
+}
+
+export function IconSettings(): JSX.Element {
+  return (
+    <svg {...base}>
+      <circle cx="10" cy="10" r="2.5" />
+      <path d="M10 1.5 v2 M10 16.5 v2 M18.5 10 h-2 M3.5 10 h-2 M16 4 l-1.4 1.4 M5.4 14.6 L4 16 M16 16 l-1.4 -1.4 M5.4 5.4 L4 4" />
+    </svg>
+  );
+}
+
+export function IconHelp(): JSX.Element {
+  return (
+    <svg {...base}>
+      <circle cx="10" cy="10" r="7" />
+      <path d="M7.5 7.5 a2.5 2.5 0 0 1 5 0 c0 1.5 -2.5 2 -2.5 3.5" />
+      <circle cx="10" cy="13.5" r="0.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function IconError(): JSX.Element {
+  return (
+    <svg {...base}>
+      <circle cx="10" cy="10" r="7" />
+      <line x1="10" y1="7" x2="10" y2="11" />
+      <circle cx="10" cy="13.5" r="0.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function IconCheck(): JSX.Element {
+  return (
+    <svg {...base} stroke-width="2">
+      <path d="M4 10 L8 14 L16 6" />
+    </svg>
+  );
+}

--- a/packages/soft-dtu/webview/src/main.tsx
+++ b/packages/soft-dtu/webview/src/main.tsx
@@ -1,0 +1,16 @@
+/**
+ * 软 DTU WebView 入口
+ *
+ * Preact 挂载到 #app，注入全局样式。
+ */
+
+import { render } from "preact";
+import { App } from "./App.tsx";
+import "./styles.css";
+
+const root = document.getElementById("app");
+if (!root) {
+  throw new Error("#app mount point not found");
+}
+
+render(<App />, root);

--- a/packages/soft-dtu/webview/src/panels/ATConsole.tsx
+++ b/packages/soft-dtu/webview/src/panels/ATConsole.tsx
@@ -1,18 +1,15 @@
 /**
- * AT 指令控制台
+ * AT 指令控制台 — Apple SF card layout
  *
- * 功能：
- *   - 输入 +++AT+XXX，按 Enter 发送
- *   - 自动补全：按 Tab 从当前选中协议的 atCommands 列表里推荐
- *   - 显示发送历史 + 接收响应（HEX + ASCII 双视图）
- *   - 解析响应：跟协议定义里的 parse 正则匹配
+ * 顶部：协议选择（parse 正则匹配用）
+ * 中部：suggestion chips + command input + Send
+ * 底部：log (TX/RX 双向, ts + ascii + hex + parsed 注释)
  *
  * 跟 UartNode 端 src/dtus/cellular.ts:queryAT 1:1 兼容（响应 +ok=xxx / +err=xxx）
  */
 
 import { useEffect, useRef, useState } from "preact/hooks";
-import { serial, protocol } from "../api.ts";
-import { uint8ToHex } from "../api.ts";
+import { serial, protocol, uint8ToHex } from "../api.ts";
 import type { ProtocolDefinition } from "../bindings.ts";
 
 interface LogEntry {
@@ -84,7 +81,7 @@ export function ATConsole() {
         ...h,
         {
           ts: Date.now(),
-          dir: "tx",
+          dir: "tx" as const,
           ascii: cmd.replace(/\r$/, ""),
           hex: uint8ToHex(data),
         },
@@ -106,50 +103,62 @@ export function ATConsole() {
 
   return (
     <div class="at-console">
-      <section class="row">
-        <label>协议</label>
-        <select
-          value={activeProtoId}
-          onChange={(e) => setActiveProtoId((e.target as HTMLSelectElement).value)}
-        >
-          <option value="">（不解析）</option>
-          {protocols.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name} ({p.atCommands?.length ?? 0} AT)
-            </option>
-          ))}
-        </select>
-        <span class="hint">Tab 自动补全 · Enter 发送</span>
-      </section>
+      <div class="panel-header">
+        <h2 class="panel-title">AT 指令</h2>
+        <p class="panel-subtitle">跟软 DTU 收发 4G AT 指令 · Tab 自动补全 · Enter 发送</p>
+      </div>
 
-      <section class="row">
-        <input
-          ref={inputRef}
-          type="text"
-          class="cmd-input"
-          value={input}
-          onInput={(e) => setInput((e.target as HTMLInputElement).value)}
-          onKeyDown={onKeyDown}
-          spellcheck={false}
-          placeholder="+++AT+PID"
-        />
-        <button class="primary" onClick={send}>发送</button>
-      </section>
-
-      {suggestions.length > 0 && (
-        <div class="suggestions">
-          {suggestions.map((s) => (
-            <button key={s} class="suggestion" onClick={() => setInput(`+++AT+${s}`)}>
-              {s}
-            </button>
-          ))}
+      <section class="card">
+        <div class="card-title">协议 (用于解析响应)</div>
+        <div class="field">
+          <select
+            value={activeProtoId}
+            onChange={(e) => setActiveProtoId((e.target as HTMLSelectElement).value)}
+          >
+            <option value="">（不解析）</option>
+            {protocols.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name} ({p.atCommands?.length ?? 0} AT)
+              </option>
+            ))}
+          </select>
         </div>
-      )}
+      </section>
+
+      <section class="card" style={{ flexShrink: 0 }}>
+        <div class="card-title">命令</div>
+
+        {suggestions.length > 0 && (
+          <div class="suggestions">
+            {suggestions.slice(0, 12).map((s) => (
+              <button key={s} class="suggestion" onClick={() => setInput(`+++AT+${s}`)}>
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div class="field-row" style={{ alignItems: "stretch" }}>
+          <input
+            ref={inputRef}
+            type="text"
+            class="cmd-input"
+            value={input}
+            onInput={(e) => setInput((e.target as HTMLInputElement).value)}
+            onKeyDown={onKeyDown}
+            spellcheck={false}
+            placeholder="+++AT+PID"
+          />
+          <button class="primary large" onClick={send}>
+            发送
+          </button>
+        </div>
+      </section>
 
       <div class="log">
         {history.slice().reverse().map((e, idx) => (
           <div key={`${e.ts}-${idx}`} class={`log-entry log-${e.dir}`}>
-            <span class="ts">{new Date(e.ts).toLocaleTimeString()}</span>
+            <span class="ts">{new Date(e.ts).toLocaleTimeString("zh-CN", { hour12: false })}</span>
             <span class="dir">{e.dir === "tx" ? "→" : "←"}</span>
             <span class="ascii">{e.ascii || "(空)"}</span>
             <span class="hex">{e.hex}</span>

--- a/packages/soft-dtu/webview/src/panels/ATConsole.tsx
+++ b/packages/soft-dtu/webview/src/panels/ATConsole.tsx
@@ -5,12 +5,23 @@
  * 中部：suggestion chips + command input + Send
  * 底部：log (TX/RX 双向, ts + ascii + hex + parsed 注释)
  *
+ * 接力补的细节:
+ *   - 命令历史 (↑↓ 翻历史, in-memory 数组)
+ *   - Tab 自动补全 (前 worker 已加)
+ *   - Cmd+Enter / Ctrl+Enter 触发发送
+ *   - Clear log 按钮 (顶部 toolbar 右侧)
+ *   - Auto-scroll (新 log 进来自动滚到底)
+ *   - ErrorBanner 替换简单 .error
+ *   - 底部 toolbar 显示快捷键 kbd hints
+ *   - onSuccess 回调 (发送成功 toast)
+ *
  * 跟 UartNode 端 src/dtus/cellular.ts:queryAT 1:1 兼容（响应 +ok=xxx / +err=xxx）
  */
 
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useRef, useState, useCallback } from "preact/hooks";
 import { serial, protocol, uint8ToHex } from "../api.ts";
 import type { ProtocolDefinition } from "../bindings.ts";
+import { ErrorBanner } from "../components/ErrorBanner.tsx";
 
 interface LogEntry {
   ts: number;
@@ -21,16 +32,29 @@ interface LogEntry {
 }
 
 const HISTORY_MAX = 200;
+const CMD_HISTORY_MAX = 50;
 
-export function ATConsole() {
+export interface ATConsoleProps {
+  /** AT 发送成功时的 toast 提示 */
+  onSuccess?: (msg: string) => void;
+}
+
+export function ATConsole({ onSuccess }: ATConsoleProps = {}) {
   const [input, setInput] = useState("+++AT+");
   const [history, setHistory] = useState<LogEntry[]>([]);
   const [protocols, setProtocols] = useState<ProtocolDefinition[]>([]);
   const [activeProtoId, setActiveProtoId] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const logEndRef = useRef<HTMLDivElement>(null);
   /** 用 ref 跟踪最近一条 tx 的指令名（rx 来时回查 parse 正则）*/
   const lastTxCmdRef = useRef<string>("");
+  /** 命令历史: ↑↓ 翻历史, 不持久化 */
+  const cmdHistoryRef = useRef<string[]>([]);
+  /** 历史指针 (-1 表示当前 input) */
+  const histIdxRef = useRef<number>(-1);
+  /** 在浏览历史时暂存当前 input (返回时还原) */
+  const histDraftRef = useRef<string>("");
 
   const activeProto = protocols.find((p) => p.id === activeProtoId);
 
@@ -58,6 +82,17 @@ export function ATConsole() {
     return unsub;
   }, [activeProto]);
 
+  // Auto-scroll: 新 log 时滚到底（如果用户没手动滚上去）
+  useEffect(() => {
+    const el = logEndRef.current?.parentElement;
+    if (!el) return;
+    // 阈值: 距离底部 ≤ 60px 算"在底部", 跟着滚
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distFromBottom < 60) {
+      logEndRef.current?.scrollIntoView({ behavior: "auto", block: "end" });
+    }
+  }, [history.length]);
+
   /** 自动补全：按 PID/VER/GVER 等关键字推荐 */
   const suggestions = (() => {
     if (!activeProto?.atCommands) return [];
@@ -68,9 +103,10 @@ export function ATConsole() {
       .map((c) => c.name);
   })();
 
-  async function send() {
+  const send = useCallback(async () => {
     setError(null);
     const cmd = input.endsWith("\r") ? input : input + "\r";
+    if (cmd.replace(/\r/g, "").trim() === "") return;
     const data = new TextEncoder().encode(cmd);
     try {
       await serial.write(data);
@@ -86,27 +122,70 @@ export function ATConsole() {
           hex: uint8ToHex(data),
         },
       ].slice(-HISTORY_MAX));
+      // 记录到命令历史（去重, push 到末尾）
+      const trimmed = cmd.replace(/\r$/, "").trim();
+      const h = cmdHistoryRef.current;
+      if (trimmed && h[h.length - 1] !== trimmed) {
+        h.push(trimmed);
+        if (h.length > CMD_HISTORY_MAX) h.shift();
+      }
+      histIdxRef.current = -1;
+      onSuccess?.(`已发送: ${trimmed}`);
     } catch (err) {
       setError(`send 失败: ${(err as Error).message}`);
     }
-  }
+  }, [input, onSuccess]);
 
   function onKeyDown(e: KeyboardEvent) {
     if (e.key === "Enter") {
+      // Cmd+Enter / Ctrl+Enter 也走 send（普通 Enter 走 send + 阻止默认）
       e.preventDefault();
       send();
     } else if (e.key === "Tab" && suggestions.length > 0) {
       e.preventDefault();
       setInput(`+++AT+${suggestions[0]}`);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const h = cmdHistoryRef.current;
+      if (h.length === 0) return;
+      if (histIdxRef.current === -1) {
+        histDraftRef.current = input;
+        histIdxRef.current = h.length - 1;
+      } else if (histIdxRef.current > 0) {
+        histIdxRef.current -= 1;
+      }
+      setInput(h[histIdxRef.current]);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const h = cmdHistoryRef.current;
+      if (histIdxRef.current === -1) return;
+      if (histIdxRef.current < h.length - 1) {
+        histIdxRef.current += 1;
+        setInput(h[histIdxRef.current]);
+      } else {
+        // 回到当前 draft
+        histIdxRef.current = -1;
+        setInput(histDraftRef.current);
+      }
     }
+  }
+
+  function clearLog() {
+    setHistory([]);
   }
 
   return (
     <div class="at-console">
       <div class="panel-header">
         <h2 class="panel-title">AT 指令</h2>
-        <p class="panel-subtitle">跟软 DTU 收发 4G AT 指令 · Tab 自动补全 · Enter 发送</p>
+        <p class="panel-subtitle">
+          跟软 DTU 收发 4G AT 指令 · Tab 自动补全 · ↑↓ 命令历史 · Enter 发送
+        </p>
       </div>
+
+      {error && (
+        <ErrorBanner onDismiss={() => setError(null)}>{error}</ErrorBanner>
+      )}
 
       <section class="card">
         <div class="card-title">协议 (用于解析响应)</div>
@@ -114,6 +193,7 @@ export function ATConsole() {
           <select
             value={activeProtoId}
             onChange={(e) => setActiveProtoId((e.target as HTMLSelectElement).value)}
+            aria-label="选择协议 (用于解析响应)"
           >
             <option value="">（不解析）</option>
             {protocols.map((p) => (
@@ -129,9 +209,15 @@ export function ATConsole() {
         <div class="card-title">命令</div>
 
         {suggestions.length > 0 && (
-          <div class="suggestions">
+          <div class="suggestions" role="listbox" aria-label="AT 指令建议">
             {suggestions.slice(0, 12).map((s) => (
-              <button key={s} class="suggestion" onClick={() => setInput(`+++AT+${s}`)}>
+              <button
+                key={s}
+                class="suggestion"
+                onClick={() => setInput(`+++AT+${s}`)}
+                role="option"
+                aria-selected="false"
+              >
                 {s}
               </button>
             ))}
@@ -148,26 +234,44 @@ export function ATConsole() {
             onKeyDown={onKeyDown}
             spellcheck={false}
             placeholder="+++AT+PID"
+            aria-label="AT 指令输入"
+            autoComplete="off"
           />
           <button class="primary large" onClick={send}>
             发送
           </button>
         </div>
+
+        <div class="cmd-toolbar">
+          <span><span class="kbd">Tab</span> 补全</span>
+          <span><span class="kbd">↑</span><span class="kbd">↓</span> 历史</span>
+          <span><span class="kbd">⌘</span><span class="kbd">⏎</span> 发送</span>
+          <span style={{ marginLeft: "auto" }}>
+            {cmdHistoryRef.current.length} 条历史
+          </span>
+        </div>
       </section>
 
-      <div class="log">
+      <div class="log" role="log" aria-live="polite" aria-label="AT 指令日志">
+        <div class="log-toolbar">
+          <span class="label">日志 · {history.length} 条</span>
+          <button onClick={clearLog} disabled={history.length === 0}>
+            清空
+          </button>
+        </div>
         {history.slice().reverse().map((e, idx) => (
           <div key={`${e.ts}-${idx}`} class={`log-entry log-${e.dir}`}>
-            <span class="ts">{new Date(e.ts).toLocaleTimeString("zh-CN", { hour12: false })}</span>
+            <span class="ts">
+              {new Date(e.ts).toLocaleTimeString("zh-CN", { hour12: false })}
+            </span>
             <span class="dir">{e.dir === "tx" ? "→" : "←"}</span>
             <span class="ascii">{e.ascii || "(空)"}</span>
             <span class="hex">{e.hex}</span>
             {e.parsed && <span class="parsed"> · {e.parsed}</span>}
           </div>
         ))}
+        <div ref={logEndRef} />
       </div>
-
-      {error && <div class="error">{error}</div>}
     </div>
   );
 }

--- a/packages/soft-dtu/webview/src/panels/ATConsole.tsx
+++ b/packages/soft-dtu/webview/src/panels/ATConsole.tsx
@@ -1,0 +1,182 @@
+/**
+ * AT 指令控制台
+ *
+ * 功能：
+ *   - 输入 +++AT+XXX，按 Enter 发送
+ *   - 自动补全：按 Tab 从当前选中协议的 atCommands 列表里推荐
+ *   - 显示发送历史 + 接收响应（HEX + ASCII 双视图）
+ *   - 解析响应：跟协议定义里的 parse 正则匹配
+ *
+ * 跟 UartNode 端 src/dtus/cellular.ts:queryAT 1:1 兼容（响应 +ok=xxx / +err=xxx）
+ */
+
+import { useEffect, useRef, useState } from "preact/hooks";
+import { serial, protocol } from "../api.ts";
+import { uint8ToHex } from "../api.ts";
+import type { ProtocolDefinition } from "../bindings.ts";
+
+interface LogEntry {
+  ts: number;
+  dir: "tx" | "rx";
+  ascii: string;
+  hex: string;
+  parsed?: string;
+}
+
+const HISTORY_MAX = 200;
+
+export function ATConsole() {
+  const [input, setInput] = useState("+++AT+");
+  const [history, setHistory] = useState<LogEntry[]>([]);
+  const [protocols, setProtocols] = useState<ProtocolDefinition[]>([]);
+  const [activeProtoId, setActiveProtoId] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  /** 用 ref 跟踪最近一条 tx 的指令名（rx 来时回查 parse 正则）*/
+  const lastTxCmdRef = useRef<string>("");
+
+  const activeProto = protocols.find((p) => p.id === activeProtoId);
+
+  // 拉协议目录（自动补全用）
+  useEffect(() => {
+    protocol.list()
+      .then((list) => {
+        setProtocols(list);
+        // 默认选第一个 4G DTU 协议（手动选 phase 1 留 todo）
+        const first4G = list.find((p) => p.type === "cellular-4g-dtu");
+        if (first4G) setActiveProtoId(first4G.id);
+      })
+      .catch((err) => setError(`协议拉取失败: ${(err as Error).message}`));
+  }, []);
+
+  // 订阅串口数据（activeProto 变化时重新订阅，让 parseResponse 拿到最新协议）
+  useEffect(() => {
+    const unsub = serial.onData((data) => {
+      const ascii = new TextDecoder("utf-8", { fatal: false }).decode(data);
+      const hex = uint8ToHex(data);
+      const parsed = parseResponse(ascii, lastTxCmdRef.current, activeProto);
+      const entry: LogEntry = { ts: Date.now(), dir: "rx", ascii, hex, parsed };
+      setHistory((h) => [...h, entry].slice(-HISTORY_MAX));
+    });
+    return unsub;
+  }, [activeProto]);
+
+  /** 自动补全：按 PID/VER/GVER 等关键字推荐 */
+  const suggestions = (() => {
+    if (!activeProto?.atCommands) return [];
+    const trimmed = input.replace(/^\+{3}AT\+/, "").toUpperCase();
+    if (!trimmed) return activeProto.atCommands.map((c) => c.name);
+    return activeProto.atCommands
+      .filter((c) => c.name.toUpperCase().includes(trimmed))
+      .map((c) => c.name);
+  })();
+
+  async function send() {
+    setError(null);
+    const cmd = input.endsWith("\r") ? input : input + "\r";
+    const data = new TextEncoder().encode(cmd);
+    try {
+      await serial.write(data);
+      // 记录最近一条 tx 的指令名（rx 来时回查 parse）
+      const cmdName = cmd.replace(/^\+{3}AT\+/, "").replace(/\r$/, "").trim().split("=")[0];
+      lastTxCmdRef.current = cmdName;
+      setHistory((h) => [
+        ...h,
+        {
+          ts: Date.now(),
+          dir: "tx",
+          ascii: cmd.replace(/\r$/, ""),
+          hex: uint8ToHex(data),
+        },
+      ].slice(-HISTORY_MAX));
+    } catch (err) {
+      setError(`send 失败: ${(err as Error).message}`);
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      send();
+    } else if (e.key === "Tab" && suggestions.length > 0) {
+      e.preventDefault();
+      setInput(`+++AT+${suggestions[0]}`);
+    }
+  }
+
+  return (
+    <div class="at-console">
+      <section class="row">
+        <label>协议</label>
+        <select
+          value={activeProtoId}
+          onChange={(e) => setActiveProtoId((e.target as HTMLSelectElement).value)}
+        >
+          <option value="">（不解析）</option>
+          {protocols.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name} ({p.atCommands?.length ?? 0} AT)
+            </option>
+          ))}
+        </select>
+        <span class="hint">Tab 自动补全 · Enter 发送</span>
+      </section>
+
+      <section class="row">
+        <input
+          ref={inputRef}
+          type="text"
+          class="cmd-input"
+          value={input}
+          onInput={(e) => setInput((e.target as HTMLInputElement).value)}
+          onKeyDown={onKeyDown}
+          spellcheck={false}
+          placeholder="+++AT+PID"
+        />
+        <button class="primary" onClick={send}>发送</button>
+      </section>
+
+      {suggestions.length > 0 && (
+        <div class="suggestions">
+          {suggestions.map((s) => (
+            <button key={s} class="suggestion" onClick={() => setInput(`+++AT+${s}`)}>
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div class="log">
+        {history.slice().reverse().map((e, idx) => (
+          <div key={`${e.ts}-${idx}`} class={`log-entry log-${e.dir}`}>
+            <span class="ts">{new Date(e.ts).toLocaleTimeString()}</span>
+            <span class="dir">{e.dir === "tx" ? "→" : "←"}</span>
+            <span class="ascii">{e.ascii || "(空)"}</span>
+            <span class="hex">{e.hex}</span>
+            {e.parsed && <span class="parsed"> · {e.parsed}</span>}
+          </div>
+        ))}
+      </div>
+
+      {error && <div class="error">{error}</div>}
+    </div>
+  );
+}
+
+/** 解析响应：按协议定义里的 parse 正则匹配 */
+function parseResponse(
+  ascii: string,
+  cmdName: string,
+  proto: ProtocolDefinition | undefined,
+): string | undefined {
+  if (!proto?.atCommands || !cmdName) return undefined;
+  const at = proto.atCommands.find((c) => c.name === cmdName);
+  if (!at) return undefined;
+  try {
+    const re = new RegExp(at.parse);
+    const m = ascii.match(re);
+    return m ? `${at.name} → ${m[1] ?? m[0]}` : "不匹配";
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/soft-dtu/webview/src/panels/ATConsole.tsx
+++ b/packages/soft-dtu/webview/src/panels/ATConsole.tsx
@@ -22,6 +22,7 @@ import { useEffect, useRef, useState, useCallback } from "preact/hooks";
 import { serial, protocol, uint8ToHex } from "../api.ts";
 import type { ProtocolDefinition } from "../bindings.ts";
 import { ErrorBanner } from "../components/ErrorBanner.tsx";
+import { IconSend, IconTrash } from "../icons.tsx";
 
 interface LogEntry {
   ts: number;
@@ -238,6 +239,7 @@ export function ATConsole({ onSuccess }: ATConsoleProps = {}) {
             autoComplete="off"
           />
           <button class="primary large" onClick={send}>
+            <IconSend />
             发送
           </button>
         </div>
@@ -256,6 +258,7 @@ export function ATConsole({ onSuccess }: ATConsoleProps = {}) {
         <div class="log-toolbar">
           <span class="label">日志 · {history.length} 条</span>
           <button onClick={clearLog} disabled={history.length === 0}>
+            <IconTrash />
             清空
           </button>
         </div>

--- a/packages/soft-dtu/webview/src/panels/ATConsole.tsx
+++ b/packages/soft-dtu/webview/src/panels/ATConsole.tsx
@@ -60,13 +60,14 @@ export function ATConsole({ onSuccess }: ATConsoleProps = {}) {
   const activeProto = protocols.find((p) => p.id === activeProtoId);
 
   // 拉协议目录（自动补全用）
+  // I3: 不自动选协议 — soft-dtu AGENTS.md 明确说"协议让用户手动选" (Cairui 2026-07-14 16:35 拍板)
+  //     "defaultProtocolId 配置项 — 已删除, 不要加回来"
+  //     跟 main.ts:108 "protocol selection: user picks manually in UI" 一致
   useEffect(() => {
     protocol.list()
       .then((list) => {
         setProtocols(list);
-        // 默认选第一个 4G DTU 协议（手动选 phase 1 留 todo）
-        const first4G = list.find((p) => p.type === "cellular-4g-dtu");
-        if (first4G) setActiveProtoId(first4G.id);
+        // activeProtoId 保持 "" 初始空, 让用户从 dropdown 选
       })
       .catch((err) => setError(`协议拉取失败: ${(err as Error).message}`));
   }, []);

--- a/packages/soft-dtu/webview/src/panels/HexView.tsx
+++ b/packages/soft-dtu/webview/src/panels/HexView.tsx
@@ -1,0 +1,110 @@
+/**
+ * HEX/ASCII 实时数据视图
+ *
+ * 功能：
+ *   - 订阅串口数据流（serial.onData）
+ *   - 实时切换 HEX / ASCII / 双视图
+ *   - 自动滚动到最新（可暂停）
+ *   - 缓冲最大 500 条记录
+ *
+ * 跟 XCOM / sscom 的"显示"面板等价，但走软 DTU 通道
+ */
+
+import { useEffect, useRef, useState } from "preact/hooks";
+import { serial, uint8ToHex } from "../api.ts";
+
+type ViewMode = "hex" | "ascii" | "both";
+
+interface Frame {
+  ts: number;
+  bytes: Uint8Array;
+}
+
+const BUFFER_MAX = 500;
+
+function bytesToAscii(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => (b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : "."))
+    .join("");
+}
+
+export function HexView() {
+  const [frames, setFrames] = useState<Frame[]>([]);
+  const [mode, setMode] = useState<ViewMode>("both");
+  const [paused, setPaused] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const unsub = serial.onData((data) => {
+      if (paused) return;
+      setFrames((prev) => {
+        const next = [...prev, { ts: Date.now(), bytes: data }];
+        return next.length > BUFFER_MAX ? next.slice(-BUFFER_MAX) : next;
+      });
+    });
+    return unsub;
+  }, [paused]);
+
+  // 自动滚动
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [frames.length]);
+
+  function clear() {
+    setFrames([]);
+  }
+
+  return (
+    <div class="hex-view">
+      <section class="row toolbar">
+        <label>视图</label>
+        <div class="seg">
+          {(["hex", "ascii", "both"] as ViewMode[]).map((m) => (
+            <button
+              key={m}
+              class={`seg-btn ${mode === m ? "active" : ""}`}
+              onClick={() => setMode(m)}
+            >
+              {m.toUpperCase()}
+            </button>
+          ))}
+        </div>
+
+        <label class="spacer">
+          <input
+            type="checkbox"
+            checked={paused}
+            onChange={(e) => setPaused((e.target as HTMLInputElement).checked)}
+          />
+          暂停
+        </label>
+        <button onClick={clear}>清空</button>
+        <span class="count">{frames.length} 帧</span>
+      </section>
+
+      <div class="hex-log" ref={containerRef}>
+        {frames.length === 0 && <div class="empty">等待数据…</div>}
+        {frames.map((f, idx) => {
+          const hex = uint8ToHex(f.bytes);
+          const ascii = bytesToAscii(f.bytes);
+          return (
+            <div key={`${f.ts}-${idx}`} class="hex-row">
+              <span class="ts">{new Date(f.ts).toLocaleTimeString()}</span>
+              {(mode === "hex" || mode === "both") && (
+                <span class="hex">{hex || "(空)"}</span>
+              )}
+              {(mode === "ascii" || mode === "both") && (
+                <span class="ascii">{ascii || "(空)"}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {error && <div class="error">{error}</div>}
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/panels/HexView.tsx
+++ b/packages/soft-dtu/webview/src/panels/HexView.tsx
@@ -2,13 +2,22 @@
  * HEX/ASCII 实时数据视图 — Apple SF card layout
  *
  * 顶部：segmented control (HEX / ASCII / 双向) + 暂停开关 (SF toggle) + 清空 + 计数
- * 中部：hex log (ts + hex + ascii 三栏)
+ * 中部：hex log (3 栏对齐: offset / hex / ascii, 16B/行)
+ *
+ * 接力补的细节:
+ *   - 三栏 hex view (offset / hex / ascii, 16B/行) — 跟 XCOM 主流 hex viewer 一致
+ *   - 不可打印字符 (0x00-0x1F 除 0x09/0x0A/0x0D) 显示 .
+ *   - Hex 栏内字节间空格, 每 8 字节多空一格 (visual 分组)
+ *   - Offset 灰底, hex 蓝色, ascii 正常色
+ *   - ErrorBanner 替换 .error
+ *   - Auto-scroll (跟 AT 一致, 用户滚上去时停)
  *
  * 跟 XCOM / sscom 的"显示"面板等价，但走软 DTU 通道
  */
 
 import { useEffect, useRef, useState } from "preact/hooks";
-import { serial, uint8ToHex } from "../api.ts";
+import { serial } from "../api.ts";
+import { ErrorBanner } from "../components/ErrorBanner.tsx";
 
 type ViewMode = "hex" | "ascii" | "both";
 
@@ -18,11 +27,43 @@ interface Frame {
 }
 
 const BUFFER_MAX = 500;
+const ROW_BYTES = 16;
 
+/** 不可打印字符 (除 \t \n \r) 显示 `.` */
 function bytesToAscii(bytes: Uint8Array): string {
   return Array.from(bytes)
-    .map((b) => (b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : "."))
+    .map((b) =>
+      (b >= 0x20 && b < 0x7f) || b === 0x09 || b === 0x0a || b === 0x0d
+        ? String.fromCharCode(b)
+        : "."
+    )
     .join("");
+}
+
+/** 16 字节一行的 hex 字符串 (字节间空格, 每 8 字节多空一格 visual 分组) */
+function formatHexRow(bytes: Uint8Array): string {
+  const groups: string[] = [];
+  for (let i = 0; i < bytes.length; i += 8) {
+    const chunk = bytes.slice(i, Math.min(i + 8, bytes.length));
+    groups.push(
+      Array.from(chunk)
+        .map((b) => b.toString(16).padStart(2, "0").toUpperCase())
+        .join(" "),
+    );
+  }
+  // 末尾补齐 16 字节的短行（让 hex 列和 ascii 列对齐）
+  const missing = ROW_BYTES - bytes.length;
+  if (missing > 0 && bytes.length < ROW_BYTES) {
+    // 把最后一段补齐: 补 2 空格/字节
+    const tail = " ".repeat(missing * 3);
+    groups[groups.length - 1] = (groups[groups.length - 1] ?? "") + tail;
+  }
+  return groups.join("  "); // 组间多 1 空格
+}
+
+/** 16 字节一行的 ascii 字符串 */
+function formatAsciiRow(bytes: Uint8Array): string {
+  return bytesToAscii(bytes);
 }
 
 export function HexView() {
@@ -30,7 +71,7 @@ export function HexView() {
   const [mode, setMode] = useState<ViewMode>("both");
   const [paused, setPaused] = useState(false);
   const [error] = useState<string | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const logEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const unsub = serial.onData((data) => {
@@ -43,10 +84,13 @@ export function HexView() {
     return unsub;
   }, [paused]);
 
-  // 自动滚动
+  // Auto-scroll: 仅当用户接近底部时跟随
   useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    const el = logEndRef.current?.parentElement;
+    if (!el) return;
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distFromBottom < 80) {
+      logEndRef.current?.scrollIntoView({ behavior: "auto", block: "end" });
     }
   }, [frames.length]);
 
@@ -58,19 +102,27 @@ export function HexView() {
     <div class="hex-view">
       <div class="panel-header">
         <h2 class="panel-title">HEX/ASCII</h2>
-        <p class="panel-subtitle">实时数据流 HEX / ASCII 切换 · 缓冲 500 帧</p>
+        <p class="panel-subtitle">
+          实时数据流 · 三栏 hex 视图 (offset / hex / ascii) · 16 字节/行 · 缓冲 500 帧
+        </p>
       </div>
+
+      {error && (
+        <ErrorBanner onDismiss={() => undefined}>{error}</ErrorBanner>
+      )}
 
       <section class="card" style={{ flexShrink: 0 }}>
         <div class="card-title">视图</div>
 
         <div class="field-row" style={{ alignItems: "center" }}>
-          <div class="seg">
+          <div class="seg" role="tablist" aria-label="HEX/ASCII 视图切换">
             {(["hex", "ascii", "both"] as ViewMode[]).map((m) => (
               <button
                 key={m}
                 class={`seg-btn ${mode === m ? "active" : ""}`}
                 onClick={() => setMode(m)}
+                role="tab"
+                aria-selected={mode === m}
               >
                 {m.toUpperCase()}
               </button>
@@ -86,31 +138,50 @@ export function HexView() {
             暂停
           </label>
 
-          <button onClick={clear}>清空</button>
+          <button onClick={clear} disabled={frames.length === 0}>
+            清空
+          </button>
           <span class="count">{frames.length} 帧</span>
         </div>
       </section>
 
-      <div class="hex-log" ref={containerRef}>
-        {frames.length === 0 && <div class="empty">等待数据…</div>}
+      <div class="hex-log" role="log" aria-live="polite" aria-label="HEX/ASCII 数据日志">
+        {frames.length === 0 && (
+          <div class="empty" role="status">等待数据…</div>
+        )}
         {frames.map((f, idx) => {
-          const hex = uint8ToHex(f.bytes);
-          const ascii = bytesToAscii(f.bytes);
+          // 每帧切成 ROW_BYTES (16) 行
+          const rows: Uint8Array[] = [];
+          for (let i = 0; i < f.bytes.length; i += ROW_BYTES) {
+            rows.push(f.bytes.slice(i, Math.min(i + ROW_BYTES, f.bytes.length)));
+          }
+          const ts = new Date(f.ts).toLocaleTimeString("zh-CN", { hour12: false });
           return (
-            <div key={`${f.ts}-${idx}`} class="hex-row">
-              <span class="ts">{new Date(f.ts).toLocaleTimeString("zh-CN", { hour12: false })}</span>
-              {(mode === "hex" || mode === "both") && (
-                <span class="hex">{hex || "(空)"}</span>
-              )}
-              {(mode === "ascii" || mode === "both") && (
-                <span class="ascii">{ascii || "(空)"}</span>
-              )}
+            <div key={`${f.ts}-${idx}`} class="hex-frame">
+              <div class="hex-row hex-row-header">
+                <span class="ts">{ts}</span>
+              </div>
+              {rows.map((row, ridx) => {
+                const offset = (idx * ROW_BYTES + ridx * ROW_BYTES) & 0xffffff;
+                return (
+                  <div key={`${f.ts}-${idx}-${ridx}`} class="hex-row">
+                    <span class="hex-offset">
+                      {offset.toString(16).padStart(6, "0").toUpperCase()}
+                    </span>
+                    {(mode === "hex" || mode === "both") && (
+                      <span class="hex-bytes">{formatHexRow(row)}</span>
+                    )}
+                    {(mode === "ascii" || mode === "both") && (
+                      <span class="hex-ascii">{formatAsciiRow(row)}</span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           );
         })}
+        <div ref={logEndRef} />
       </div>
-
-      {error && <div class="error">{error}</div>}
     </div>
   );
 }

--- a/packages/soft-dtu/webview/src/panels/HexView.tsx
+++ b/packages/soft-dtu/webview/src/panels/HexView.tsx
@@ -1,11 +1,8 @@
 /**
- * HEX/ASCII 实时数据视图
+ * HEX/ASCII 实时数据视图 — Apple SF card layout
  *
- * 功能：
- *   - 订阅串口数据流（serial.onData）
- *   - 实时切换 HEX / ASCII / 双视图
- *   - 自动滚动到最新（可暂停）
- *   - 缓冲最大 500 条记录
+ * 顶部：segmented control (HEX / ASCII / 双向) + 暂停开关 (SF toggle) + 清空 + 计数
+ * 中部：hex log (ts + hex + ascii 三栏)
  *
  * 跟 XCOM / sscom 的"显示"面板等价，但走软 DTU 通道
  */
@@ -32,7 +29,7 @@ export function HexView() {
   const [frames, setFrames] = useState<Frame[]>([]);
   const [mode, setMode] = useState<ViewMode>("both");
   const [paused, setPaused] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -59,30 +56,39 @@ export function HexView() {
 
   return (
     <div class="hex-view">
-      <section class="row toolbar">
-        <label>视图</label>
-        <div class="seg">
-          {(["hex", "ascii", "both"] as ViewMode[]).map((m) => (
-            <button
-              key={m}
-              class={`seg-btn ${mode === m ? "active" : ""}`}
-              onClick={() => setMode(m)}
-            >
-              {m.toUpperCase()}
-            </button>
-          ))}
-        </div>
+      <div class="panel-header">
+        <h2 class="panel-title">HEX/ASCII</h2>
+        <p class="panel-subtitle">实时数据流 HEX / ASCII 切换 · 缓冲 500 帧</p>
+      </div>
 
-        <label class="spacer">
-          <input
-            type="checkbox"
-            checked={paused}
-            onChange={(e) => setPaused((e.target as HTMLInputElement).checked)}
-          />
-          暂停
-        </label>
-        <button onClick={clear}>清空</button>
-        <span class="count">{frames.length} 帧</span>
+      <section class="card" style={{ flexShrink: 0 }}>
+        <div class="card-title">视图</div>
+
+        <div class="field-row" style={{ alignItems: "center" }}>
+          <div class="seg">
+            {(["hex", "ascii", "both"] as ViewMode[]).map((m) => (
+              <button
+                key={m}
+                class={`seg-btn ${mode === m ? "active" : ""}`}
+                onClick={() => setMode(m)}
+              >
+                {m.toUpperCase()}
+              </button>
+            ))}
+          </div>
+
+          <label class="toggle">
+            <input
+              type="checkbox"
+              checked={paused}
+              onChange={(e) => setPaused((e.target as HTMLInputElement).checked)}
+            />
+            暂停
+          </label>
+
+          <button onClick={clear}>清空</button>
+          <span class="count">{frames.length} 帧</span>
+        </div>
       </section>
 
       <div class="hex-log" ref={containerRef}>
@@ -92,7 +98,7 @@ export function HexView() {
           const ascii = bytesToAscii(f.bytes);
           return (
             <div key={`${f.ts}-${idx}`} class="hex-row">
-              <span class="ts">{new Date(f.ts).toLocaleTimeString()}</span>
+              <span class="ts">{new Date(f.ts).toLocaleTimeString("zh-CN", { hour12: false })}</span>
               {(mode === "hex" || mode === "both") && (
                 <span class="hex">{hex || "(空)"}</span>
               )}

--- a/packages/soft-dtu/webview/src/panels/HexView.tsx
+++ b/packages/soft-dtu/webview/src/panels/HexView.tsx
@@ -18,6 +18,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { serial } from "../api.ts";
 import { ErrorBanner } from "../components/ErrorBanner.tsx";
+import { IconPlay, IconPause, IconTrash } from "../icons.tsx";
 
 type ViewMode = "hex" | "ascii" | "both";
 
@@ -135,10 +136,20 @@ export function HexView() {
               checked={paused}
               onChange={(e) => setPaused((e.target as HTMLInputElement).checked)}
             />
-            暂停
+            {paused ? "已暂停" : "实时"}
           </label>
+          <button
+            class={paused ? "primary" : ""}
+            onClick={() => setPaused((p) => !p)}
+            aria-label={paused ? "恢复" : "暂停"}
+            title={paused ? "恢复 streaming" : "暂停 streaming"}
+          >
+            {paused ? <IconPlay /> : <IconPause />}
+            {paused ? "恢复" : "暂停"}
+          </button>
 
           <button onClick={clear} disabled={frames.length === 0}>
+            <IconTrash />
             清空
           </button>
           <span class="count">{frames.length} 帧</span>

--- a/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
+++ b/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
@@ -1,11 +1,8 @@
 /**
- * 协议定义浏览器
+ * 协议定义浏览器 — Apple SF card layout
  *
- * 功能：
- *   - 拉 server `/api/v2/protocols` 列协议
- *   - 点开看 AT 指令 / 寄存器表 / 默认串口参数
- *   - 手动选协议（不预选，Cairui 2026-07-14 16:35 拍板）
- *   - 刷新按钮强制 re-fetch（忽略 5min 缓存）
+ * 顶部：协议 select + 强制刷新 + 计数
+ * 详情（card）：标题 / meta dl / 注册包 / AT 指令表 / 寄存器表 / 默认串口参数 / 元数据
  *
  * 离线 fallback 显示提示（server 不可达时只有 modbus RTU）
  */
@@ -41,23 +38,33 @@ export function ProtocolViewer() {
 
   return (
     <div class="protocol-viewer">
-      <section class="row toolbar">
-        <label>协议</label>
-        <select
-          value={selectedId}
-          onChange={(e) => setSelectedId((e.target as HTMLSelectElement).value)}
-        >
-          <option value="">（不选）</option>
-          {protocols.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name} [{p.type}]
-            </option>
-          ))}
-        </select>
-        <button onClick={() => load(true)} disabled={loading}>
-          {loading ? "刷新中…" : "强制刷新"}
-        </button>
-        <span class="count">{protocols.length} 个协议</span>
+      <div class="panel-header">
+        <h2 class="panel-title">协议定义</h2>
+        <p class="panel-subtitle">从 server 拉的协议目录 · 手动选协议查看详情</p>
+      </div>
+
+      <section class="card">
+        <div class="card-title">选择</div>
+
+        <div class="field-row" style={{ alignItems: "center" }}>
+          <div class="field" style={{ flex: 1, marginBottom: 0 }}>
+            <select
+              value={selectedId}
+              onChange={(e) => setSelectedId((e.target as HTMLSelectElement).value)}
+            >
+              <option value="">（不选）</option>
+              {protocols.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name} [{p.type}]
+                </option>
+              ))}
+            </select>
+          </div>
+          <button onClick={() => load(true)} disabled={loading}>
+            {loading ? "刷新中…" : "强制刷新"}
+          </button>
+          <span class="count">{protocols.length} 个协议</span>
+        </div>
       </section>
 
       {!selected && protocols.length === 1 && protocols[0].id === "modbus-rtu-default" && (

--- a/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
+++ b/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
@@ -18,7 +18,7 @@ import { protocol } from "../api.ts";
 import type { ProtocolDefinition } from "../bindings.ts";
 import { EmptyState } from "../components/EmptyState.tsx";
 import { ErrorBanner } from "../components/ErrorBanner.tsx";
-import { IconProtocol } from "../icons.tsx";
+import { IconProtocol, IconRefresh } from "../icons.tsx";
 
 export function ProtocolViewer() {
   const [protocols, setProtocols] = useState<ProtocolDefinition[]>([]);
@@ -86,6 +86,7 @@ export function ProtocolViewer() {
             </select>
           </div>
           <button onClick={() => load(true)} disabled={loading}>
+            <IconRefresh />
             {loading ? "刷新中…" : "强制刷新"}
           </button>
           <span class="count">{protocols.length} 个协议</span>

--- a/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
+++ b/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
@@ -2,7 +2,13 @@
  * 协议定义浏览器 — Apple SF card layout
  *
  * 顶部：协议 select + 强制刷新 + 计数
- * 详情（card）：标题 / meta dl / 注册包 / AT 指令表 / 寄存器表 / 默认串口参数 / 元数据
+ * 详情（card）：标题 / meta dl (dt/dd SF card 风格) / 注册包 / AT 指令表 / 寄存器表 / 默认串口参数 / 元数据
+ *
+ * 接力补的细节:
+ *   - EmptyState 组件 (没选协议时显示, 大 icon + 标题 + hint)
+ *   - ErrorBanner 替换简单 .error
+ *   - meta dl 用 SF card 风格 (column 1 caption uppercase, column 2 mono code)
+ *   - 全局 table caption 大写 (跟 meta dt 一致)
  *
  * 离线 fallback 显示提示（server 不可达时只有 modbus RTU）
  */
@@ -10,12 +16,16 @@
 import { useEffect, useState } from "preact/hooks";
 import { protocol } from "../api.ts";
 import type { ProtocolDefinition } from "../bindings.ts";
+import { EmptyState } from "../components/EmptyState.tsx";
+import { ErrorBanner } from "../components/ErrorBanner.tsx";
+import { IconProtocol } from "../icons.tsx";
 
 export function ProtocolViewer() {
   const [protocols, setProtocols] = useState<ProtocolDefinition[]>([]);
   const [selectedId, setSelectedId] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   async function load(force = false) {
     setLoading(true);
@@ -27,6 +37,7 @@ export function ProtocolViewer() {
       setError(`协议拉取失败: ${(err as Error).message}`);
     } finally {
       setLoading(false);
+      setLoaded(true);
     }
   }
 
@@ -35,6 +46,9 @@ export function ProtocolViewer() {
   }, []);
 
   const selected = protocols.find((p) => p.id === selectedId);
+  const isOfflineFallback = !selected
+    && protocols.length === 1
+    && protocols[0]?.id === "modbus-rtu-default";
 
   return (
     <div class="protocol-viewer">
@@ -42,6 +56,16 @@ export function ProtocolViewer() {
         <h2 class="panel-title">协议定义</h2>
         <p class="panel-subtitle">从 server 拉的协议目录 · 手动选协议查看详情</p>
       </div>
+
+      {error && (
+        <ErrorBanner onDismiss={() => setError(null)}>{error}</ErrorBanner>
+      )}
+
+      {isOfflineFallback && (
+        <div class="warn">
+          ⚠️ 协议目录是离线模式（server 不可达），只显示 modbus RTU fallback。
+        </div>
+      )}
 
       <section class="card">
         <div class="card-title">选择</div>
@@ -51,6 +75,7 @@ export function ProtocolViewer() {
             <select
               value={selectedId}
               onChange={(e) => setSelectedId((e.target as HTMLSelectElement).value)}
+              aria-label="选择协议"
             >
               <option value="">（不选）</option>
               {protocols.map((p) => (
@@ -67,31 +92,37 @@ export function ProtocolViewer() {
         </div>
       </section>
 
-      {!selected && protocols.length === 1 && protocols[0].id === "modbus-rtu-default" && (
-        <div class="warn">
-          ⚠️ 协议目录是离线模式（server 不可达），只显示 modbus RTU fallback。
-        </div>
+      {!selected && loaded && (
+        <EmptyState
+          icon={<IconProtocol />}
+          title="选择一个协议"
+          hint="从上方下拉菜单选择软 DTU 协议, 查看 AT 指令和寄存器表"
+        />
       )}
 
       {selected && (
         <div class="protocol-detail">
           <h2>{selected.name}</h2>
           <dl class="meta">
-            <dt>ID</dt><dd><code>{selected.id}</code></dd>
-            <dt>类型</dt><dd>{selected.type}</dd>
-            {selected.manufacturer && <><dt>厂商</dt><dd>{selected.manufacturer}</dd></>}
-            {selected.model && <><dt>型号</dt><dd>{selected.model}</dd></>}
-            {selected.category && <><dt>分类</dt><dd>{selected.category}</dd></>}
-            {selected.version && <><dt>版本</dt><dd>{selected.version}</dd></>}
-            {selected.transport && <><dt>传输</dt><dd><code>{selected.transport}</code></dd></>}
+            <dt>ID</dt>
+            <dd><code>{selected.id}</code></dd>
+            <dt>类型</dt>
+            <dd>{selected.type}</dd>
+            {selected.manufacturer && (<><dt>厂商</dt><dd>{selected.manufacturer}</dd></>)}
+            {selected.model && (<><dt>型号</dt><dd>{selected.model}</dd></>)}
+            {selected.category && (<><dt>分类</dt><dd>{selected.category}</dd></>)}
+            {selected.version && (<><dt>版本</dt><dd>{selected.version}</dd></>)}
+            {selected.transport && (<><dt>传输</dt><dd><code>{selected.transport}</code></dd></>)}
           </dl>
 
           {selected.register && (
             <section>
               <h3>注册包</h3>
               <dl class="meta">
-                <dt>格式</dt><dd><code>{selected.register.format}</code></dd>
-                <dt>IMEI 位数</dt><dd>{selected.register.imeiLength}</dd>
+                <dt>格式</dt>
+                <dd><code>{selected.register.format}</code></dd>
+                <dt>IMEI 位数</dt>
+                <dd>{selected.register.imeiLength}</dd>
                 <dt>触发仪式</dt>
                 <dd>{selected.register.triggerOnInvite ? "是（+++AT+ 后）" : "否"}</dd>
               </dl>
@@ -160,10 +191,14 @@ export function ProtocolViewer() {
             <section>
               <h3>默认串口参数</h3>
               <dl class="meta">
-                <dt>波特率</dt><dd>{selected.defaultSerial.baudRate}</dd>
-                <dt>数据位</dt><dd>{selected.defaultSerial.dataBits}</dd>
-                <dt>停止位</dt><dd>{selected.defaultSerial.stopBits}</dd>
-                <dt>校验</dt><dd>{selected.defaultSerial.parity}</dd>
+                <dt>波特率</dt>
+                <dd>{selected.defaultSerial.baudRate}</dd>
+                <dt>数据位</dt>
+                <dd>{selected.defaultSerial.dataBits}</dd>
+                <dt>停止位</dt>
+                <dd>{selected.defaultSerial.stopBits}</dd>
+                <dt>校验</dt>
+                <dd>{selected.defaultSerial.parity}</dd>
               </dl>
             </section>
           )}
@@ -181,8 +216,6 @@ export function ProtocolViewer() {
           )}
         </div>
       )}
-
-      {error && <div class="error">{error}</div>}
     </div>
   );
 }

--- a/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
+++ b/packages/soft-dtu/webview/src/panels/ProtocolViewer.tsx
@@ -1,0 +1,181 @@
+/**
+ * 协议定义浏览器
+ *
+ * 功能：
+ *   - 拉 server `/api/v2/protocols` 列协议
+ *   - 点开看 AT 指令 / 寄存器表 / 默认串口参数
+ *   - 手动选协议（不预选，Cairui 2026-07-14 16:35 拍板）
+ *   - 刷新按钮强制 re-fetch（忽略 5min 缓存）
+ *
+ * 离线 fallback 显示提示（server 不可达时只有 modbus RTU）
+ */
+
+import { useEffect, useState } from "preact/hooks";
+import { protocol } from "../api.ts";
+import type { ProtocolDefinition } from "../bindings.ts";
+
+export function ProtocolViewer() {
+  const [protocols, setProtocols] = useState<ProtocolDefinition[]>([]);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function load(force = false) {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = force ? await protocol.refresh() : await protocol.list();
+      setProtocols(list);
+    } catch (err) {
+      setError(`协议拉取失败: ${(err as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load(false);
+  }, []);
+
+  const selected = protocols.find((p) => p.id === selectedId);
+
+  return (
+    <div class="protocol-viewer">
+      <section class="row toolbar">
+        <label>协议</label>
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId((e.target as HTMLSelectElement).value)}
+        >
+          <option value="">（不选）</option>
+          {protocols.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name} [{p.type}]
+            </option>
+          ))}
+        </select>
+        <button onClick={() => load(true)} disabled={loading}>
+          {loading ? "刷新中…" : "强制刷新"}
+        </button>
+        <span class="count">{protocols.length} 个协议</span>
+      </section>
+
+      {!selected && protocols.length === 1 && protocols[0].id === "modbus-rtu-default" && (
+        <div class="warn">
+          ⚠️ 协议目录是离线模式（server 不可达），只显示 modbus RTU fallback。
+        </div>
+      )}
+
+      {selected && (
+        <div class="protocol-detail">
+          <h2>{selected.name}</h2>
+          <dl class="meta">
+            <dt>ID</dt><dd><code>{selected.id}</code></dd>
+            <dt>类型</dt><dd>{selected.type}</dd>
+            {selected.manufacturer && <><dt>厂商</dt><dd>{selected.manufacturer}</dd></>}
+            {selected.model && <><dt>型号</dt><dd>{selected.model}</dd></>}
+            {selected.category && <><dt>分类</dt><dd>{selected.category}</dd></>}
+            {selected.version && <><dt>版本</dt><dd>{selected.version}</dd></>}
+            {selected.transport && <><dt>传输</dt><dd><code>{selected.transport}</code></dd></>}
+          </dl>
+
+          {selected.register && (
+            <section>
+              <h3>注册包</h3>
+              <dl class="meta">
+                <dt>格式</dt><dd><code>{selected.register.format}</code></dd>
+                <dt>IMEI 位数</dt><dd>{selected.register.imeiLength}</dd>
+                <dt>触发仪式</dt>
+                <dd>{selected.register.triggerOnInvite ? "是（+++AT+ 后）" : "否"}</dd>
+              </dl>
+            </section>
+          )}
+
+          {selected.atCommands && selected.atCommands.length > 0 && (
+            <section>
+              <h3>AT 指令 ({selected.atCommands.length})</h3>
+              <table class="at-table">
+                <thead>
+                  <tr>
+                    <th>名</th>
+                    <th>指令</th>
+                    <th>解析正则</th>
+                    <th>说明</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selected.atCommands.map((c) => (
+                    <tr key={c.name}>
+                      <td><code>{c.name}</code></td>
+                      <td><code>{c.cmd}</code></td>
+                      <td><code class="regex">{c.parse}</code></td>
+                      <td>{c.description ?? ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          )}
+
+          {selected.registers && selected.registers.length > 0 && (
+            <section>
+              <h3>Modbus 寄存器 ({selected.registers.length})</h3>
+              <table class="reg-table">
+                <thead>
+                  <tr>
+                    <th>地址</th>
+                    <th>名</th>
+                    <th>类型</th>
+                    <th>数据类型</th>
+                    <th>单位</th>
+                    <th>系数</th>
+                    <th>说明</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selected.registers.map((r, idx) => (
+                    <tr key={`${r.address}-${idx}`}>
+                      <td><code>{r.address}</code></td>
+                      <td>{r.name}</td>
+                      <td>{r.type}</td>
+                      <td>{r.dataType}</td>
+                      <td>{r.unit ?? ""}</td>
+                      <td>{r.scale ?? ""}</td>
+                      <td>{r.description ?? ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          )}
+
+          {selected.defaultSerial && (
+            <section>
+              <h3>默认串口参数</h3>
+              <dl class="meta">
+                <dt>波特率</dt><dd>{selected.defaultSerial.baudRate}</dd>
+                <dt>数据位</dt><dd>{selected.defaultSerial.dataBits}</dd>
+                <dt>停止位</dt><dd>{selected.defaultSerial.stopBits}</dd>
+                <dt>校验</dt><dd>{selected.defaultSerial.parity}</dd>
+              </dl>
+            </section>
+          )}
+
+          {selected.metadata && Object.keys(selected.metadata).length > 0 && (
+            <section>
+              <h3>元数据</h3>
+              <dl class="meta">
+                {Object.entries(selected.metadata).flatMap(([k, v]) => [
+                  <dt key={`${k}-dt`}>{k}</dt>,
+                  <dd key={`${k}-dd`}>{v}</dd>,
+                ])}
+              </dl>
+            </section>
+          )}
+        </div>
+      )}
+
+      {error && <div class="error">{error}</div>}
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
+++ b/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
@@ -1,11 +1,9 @@
 /**
- * 串口配置面板
+ * 串口配置面板 — Apple SF card layout
  *
- * 功能：
- *   - 列出本机可用串口（/api/serial/list）
- *   - 选串口 + 波特率/数据位/停止位/校验
- *   - open / close 按钮
- *   - 显示当前打开的串口
+ * 字段：串口 / 波特率 / 数据位 / 停止位 / 校验
+ * 按钮：打开串口（primary）/ 关闭串口（danger）
+ * 状态：状态 pill（已打开：path @ baudRate / 未打开）
  *
  * 用 http api 而非直接 bindings（Phase 1 走 HTTP）
  */
@@ -17,7 +15,7 @@ import type { SerialPortInfo, SerialOptions } from "../bindings.ts";
 const BAUD_RATES = [1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
 const DATA_BITS: Array<5 | 6 | 7 | 8> = [5, 6, 7, 8];
 const STOP_BITS: Array<1 | 2> = [1, 2];
-const PARITIES: Array<SerialOptions["parity"]> = ["none", "even", "odd", "mark", "space"];
+const PARITIES: Array<NonNullable<SerialOptions["parity"]>> = ["none", "even", "odd", "mark", "space"];
 
 export function SerialConfig() {
   const [ports, setPorts] = useState<SerialPortInfo[]>([]);
@@ -87,89 +85,116 @@ export function SerialConfig() {
 
   return (
     <div class="serial-config">
-      <section class="row">
-        <label>串口</label>
-        <select
-          value={selected}
-          onChange={(e) => setSelected((e.target as HTMLSelectElement).value)}
-          disabled={isOpen}
-        >
-          {ports.length === 0 && <option value="">（无可用串口）</option>}
-          {ports.map((p) => (
-            <option key={p.path} value={p.path}>
-              {p.path}
-              {p.manufacturer ? ` (${p.manufacturer})` : ""}
-            </option>
-          ))}
-        </select>
-        <button onClick={refreshPorts} disabled={loading || isOpen}>
-          {loading ? "刷新中…" : "刷新"}
-        </button>
+      <div class="panel-header">
+        <h2 class="panel-title">串口配置</h2>
+        <p class="panel-subtitle">选择并打开设备的串口</p>
+      </div>
+
+      <section class="card">
+        <div class="card-title">设备</div>
+
+        <div class="field">
+          <span class="field-label">串口</span>
+          <div class="field-row">
+            <select
+              value={selected}
+              onChange={(e) => setSelected((e.target as HTMLSelectElement).value)}
+              disabled={isOpen}
+              style={{ flex: 1, minWidth: "180px" }}
+            >
+              {ports.length === 0 && <option value="">（无可用串口）</option>}
+              {ports.map((p) => (
+                <option key={p.path} value={p.path}>
+                  {p.path}
+                  {p.manufacturer ? ` (${p.manufacturer})` : ""}
+                </option>
+              ))}
+            </select>
+            <button onClick={refreshPorts} disabled={loading || isOpen}>
+              {loading ? "刷新中…" : "刷新"}
+            </button>
+          </div>
+        </div>
       </section>
 
-      <section class="row">
-        <label>波特率</label>
-        <select
-          value={baudRate}
-          onChange={(e) => setBaudRate(Number((e.target as HTMLSelectElement).value))}
-          disabled={isOpen}
-        >
-          {BAUD_RATES.map((b) => (
-            <option key={b} value={b}>{b}</option>
-          ))}
-        </select>
+      <section class="card">
+        <div class="card-title">参数</div>
+
+        <div class="field">
+          <span class="field-label">波特率</span>
+          <select
+            value={baudRate}
+            onChange={(e) => setBaudRate(Number((e.target as HTMLSelectElement).value))}
+            disabled={isOpen}
+            style={{ maxWidth: "160px" }}
+          >
+            {BAUD_RATES.map((b) => (
+              <option key={b} value={b}>{b}</option>
+            ))}
+          </select>
+        </div>
+
+        <div class="field-row">
+          <div class="field">
+            <span class="field-label">数据位</span>
+            <select
+              value={dataBits}
+              onChange={(e) => setDataBits(Number((e.target as HTMLSelectElement).value) as 5 | 6 | 7 | 8)}
+              disabled={isOpen}
+            >
+              {DATA_BITS.map((b) => (
+                <option key={b} value={b}>{b}</option>
+              ))}
+            </select>
+          </div>
+
+          <div class="field">
+            <span class="field-label">停止位</span>
+            <select
+              value={stopBits}
+              onChange={(e) => setStopBits(Number((e.target as HTMLSelectElement).value) as 1 | 2)}
+              disabled={isOpen}
+            >
+              {STOP_BITS.map((b) => (
+                <option key={b} value={b}>{b}</option>
+              ))}
+            </select>
+          </div>
+
+          <div class="field">
+            <span class="field-label">校验</span>
+            <select
+              value={parity}
+              onChange={(e) => setParity((e.target as HTMLSelectElement).value as SerialOptions["parity"])}
+              disabled={isOpen}
+            >
+              {PARITIES.map((p) => (
+                <option key={p} value={p}>
+                  {p === "none" ? "N" : p.charAt(0).toUpperCase()}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
       </section>
 
-      <section class="row">
-        <label>数据位</label>
-        <select
-          value={dataBits}
-          onChange={(e) => setDataBits(Number((e.target as HTMLSelectElement).value) as 5 | 6 | 7 | 8)}
-          disabled={isOpen}
-        >
-          {DATA_BITS.map((b) => (
-            <option key={b} value={b}>{b}</option>
-          ))}
-        </select>
+      <section class="card">
+        <div class="card-title">连接</div>
 
-        <label>停止位</label>
-        <select
-          value={stopBits}
-          onChange={(e) => setStopBits(Number((e.target as HTMLSelectElement).value) as 1 | 2)}
-          disabled={isOpen}
-        >
-          {STOP_BITS.map((b) => (
-            <option key={b} value={b}>{b}</option>
-          ))}
-        </select>
-
-        <label>校验</label>
-        <select
-          value={parity}
-          onChange={(e) => setParity((e.target as HTMLSelectElement).value as SerialOptions["parity"])}
-          disabled={isOpen}
-        >
-          {PARITIES.map((p) => (
-            <option key={p} value={p}>
-              {p === "none" ? "N" : p[0].toUpperCase()}
-            </option>
-          ))}
-        </select>
-      </section>
-
-      <section class="row actions">
-        {!isOpen ? (
-          <button class="primary" onClick={handleOpen} disabled={!selected}>
-            打开串口
-          </button>
-        ) : (
-          <button class="danger" onClick={handleClose}>
-            关闭串口
-          </button>
-        )}
-        <span class={`status ${isOpen ? "open" : "closed"}`}>
-          {isOpen ? `已打开: ${selected} @ ${baudRate}` : "未打开"}
-        </span>
+        <div class="btn-row">
+          {!isOpen ? (
+            <button class="primary large" onClick={handleOpen} disabled={!selected}>
+              打开串口
+            </button>
+          ) : (
+            <button class="danger large" onClick={handleClose}>
+              关闭串口
+            </button>
+          )}
+          <span class={`status-tag ${isOpen ? "open" : "closed"}`}>
+            {isOpen ? `已打开: ${selected} @ ${baudRate}` : "未打开"}
+          </span>
+        </div>
       </section>
 
       {error && <div class="error">{error}</div>}

--- a/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
+++ b/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
@@ -18,7 +18,7 @@ import { serial, getSerialStatus } from "../api.ts";
 import type { SerialPortInfo, SerialOptions } from "../bindings.ts";
 import { ErrorBanner } from "../components/ErrorBanner.tsx";
 import { EmptyState } from "../components/EmptyState.tsx";
-import { IconSerial } from "../icons.tsx";
+import { IconSerial, IconRefresh, IconSend, IconClose } from "../icons.tsx";
 
 const BAUD_RATES = [1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
 const DATA_BITS: Array<5 | 6 | 7 | 8> = [5, 6, 7, 8];
@@ -133,6 +133,7 @@ export function SerialConfig({ onSuccess }: SerialConfigProps = {}) {
               ))}
             </select>
             <button onClick={refreshPorts} disabled={loading || isOpen}>
+              <IconRefresh />
               {loading ? "刷新中…" : "刷新"}
             </button>
           </div>
@@ -214,10 +215,12 @@ export function SerialConfig({ onSuccess }: SerialConfigProps = {}) {
               onClick={handleOpen}
               disabled={!selected}
             >
+              <IconSend />
               打开串口
             </button>
           ) : (
             <button class="danger large" onClick={handleClose}>
+              <IconClose />
               关闭串口
             </button>
           )}
@@ -234,6 +237,7 @@ export function SerialConfig({ onSuccess }: SerialConfigProps = {}) {
           hint="检查 USB 转 485 转换器是否插入, 或点击刷新重试"
           action={
             <button onClick={refreshPorts} disabled={loading}>
+              <IconRefresh />
               {loading ? "刷新中…" : "刷新串口列表"}
             </button>
           }

--- a/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
+++ b/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
@@ -1,0 +1,178 @@
+/**
+ * 串口配置面板
+ *
+ * 功能：
+ *   - 列出本机可用串口（/api/serial/list）
+ *   - 选串口 + 波特率/数据位/停止位/校验
+ *   - open / close 按钮
+ *   - 显示当前打开的串口
+ *
+ * 用 http api 而非直接 bindings（Phase 1 走 HTTP）
+ */
+
+import { useEffect, useState } from "preact/hooks";
+import { serial, getSerialStatus } from "../api.ts";
+import type { SerialPortInfo, SerialOptions } from "../bindings.ts";
+
+const BAUD_RATES = [1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
+const DATA_BITS: Array<5 | 6 | 7 | 8> = [5, 6, 7, 8];
+const STOP_BITS: Array<1 | 2> = [1, 2];
+const PARITIES: Array<SerialOptions["parity"]> = ["none", "even", "odd", "mark", "space"];
+
+export function SerialConfig() {
+  const [ports, setPorts] = useState<SerialPortInfo[]>([]);
+  const [selected, setSelected] = useState<string>("");
+  const [baudRate, setBaudRate] = useState(115200);
+  const [dataBits, setDataBits] = useState<5 | 6 | 7 | 8>(8);
+  const [stopBits, setStopBits] = useState<1 | 2>(1);
+  const [parity, setParity] = useState<SerialOptions["parity"]>("none");
+  const [isOpen, setIsOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function refreshPorts() {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await serial.list();
+      setPorts(list);
+      if (list.length > 0 && !selected) {
+        setSelected(list[0].path);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function refreshStatus() {
+    try {
+      const s = await getSerialStatus();
+      setIsOpen(s.isOpen);
+    } catch (err) {
+      // 后端没起 / 路径不存在 — ignore
+      void err;
+    }
+  }
+
+  useEffect(() => {
+    refreshPorts();
+    refreshStatus();
+  }, []);
+
+  async function handleOpen() {
+    if (!selected) {
+      setError("请先选串口");
+      return;
+    }
+    setError(null);
+    try {
+      await serial.open(selected, { baudRate, dataBits, stopBits, parity });
+      setIsOpen(true);
+    } catch (err) {
+      setError(`open 失败: ${(err as Error).message}`);
+    }
+  }
+
+  async function handleClose() {
+    setError(null);
+    try {
+      await serial.close();
+      setIsOpen(false);
+    } catch (err) {
+      setError(`close 失败: ${(err as Error).message}`);
+    }
+  }
+
+  return (
+    <div class="serial-config">
+      <section class="row">
+        <label>串口</label>
+        <select
+          value={selected}
+          onChange={(e) => setSelected((e.target as HTMLSelectElement).value)}
+          disabled={isOpen}
+        >
+          {ports.length === 0 && <option value="">（无可用串口）</option>}
+          {ports.map((p) => (
+            <option key={p.path} value={p.path}>
+              {p.path}
+              {p.manufacturer ? ` (${p.manufacturer})` : ""}
+            </option>
+          ))}
+        </select>
+        <button onClick={refreshPorts} disabled={loading || isOpen}>
+          {loading ? "刷新中…" : "刷新"}
+        </button>
+      </section>
+
+      <section class="row">
+        <label>波特率</label>
+        <select
+          value={baudRate}
+          onChange={(e) => setBaudRate(Number((e.target as HTMLSelectElement).value))}
+          disabled={isOpen}
+        >
+          {BAUD_RATES.map((b) => (
+            <option key={b} value={b}>{b}</option>
+          ))}
+        </select>
+      </section>
+
+      <section class="row">
+        <label>数据位</label>
+        <select
+          value={dataBits}
+          onChange={(e) => setDataBits(Number((e.target as HTMLSelectElement).value) as 5 | 6 | 7 | 8)}
+          disabled={isOpen}
+        >
+          {DATA_BITS.map((b) => (
+            <option key={b} value={b}>{b}</option>
+          ))}
+        </select>
+
+        <label>停止位</label>
+        <select
+          value={stopBits}
+          onChange={(e) => setStopBits(Number((e.target as HTMLSelectElement).value) as 1 | 2)}
+          disabled={isOpen}
+        >
+          {STOP_BITS.map((b) => (
+            <option key={b} value={b}>{b}</option>
+          ))}
+        </select>
+
+        <label>校验</label>
+        <select
+          value={parity}
+          onChange={(e) => setParity((e.target as HTMLSelectElement).value as SerialOptions["parity"])}
+          disabled={isOpen}
+        >
+          {PARITIES.map((p) => (
+            <option key={p} value={p}>
+              {p === "none" ? "N" : p[0].toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      <section class="row actions">
+        {!isOpen ? (
+          <button class="primary" onClick={handleOpen} disabled={!selected}>
+            打开串口
+          </button>
+        ) : (
+          <button class="danger" onClick={handleClose}>
+            关闭串口
+          </button>
+        )}
+        <span class={`status ${isOpen ? "open" : "closed"}`}>
+          {isOpen ? `已打开: ${selected} @ ${baudRate}` : "未打开"}
+        </span>
+      </section>
+
+      {error && <div class="error">{error}</div>}
+    </div>
+  );
+}

--- a/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
+++ b/packages/soft-dtu/webview/src/panels/SerialConfig.tsx
@@ -5,19 +5,32 @@
  * 按钮：打开串口（primary）/ 关闭串口（danger）
  * 状态：状态 pill（已打开：path @ baudRate / 未打开）
  *
+ * 接力补的细节:
+ *   - ErrorBanner 组件替换简单 .error (加 icon + dismiss)
+ *   - onSuccess 回调通知 App toast ("串口已打开" / "已关闭")
+ *   - empty state (无串口设备) 用 EmptyState 组件
+ *
  * 用 http api 而非直接 bindings（Phase 1 走 HTTP）
  */
 
 import { useEffect, useState } from "preact/hooks";
 import { serial, getSerialStatus } from "../api.ts";
 import type { SerialPortInfo, SerialOptions } from "../bindings.ts";
+import { ErrorBanner } from "../components/ErrorBanner.tsx";
+import { EmptyState } from "../components/EmptyState.tsx";
+import { IconSerial } from "../icons.tsx";
 
 const BAUD_RATES = [1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
 const DATA_BITS: Array<5 | 6 | 7 | 8> = [5, 6, 7, 8];
 const STOP_BITS: Array<1 | 2> = [1, 2];
 const PARITIES: Array<NonNullable<SerialOptions["parity"]>> = ["none", "even", "odd", "mark", "space"];
 
-export function SerialConfig() {
+export interface SerialConfigProps {
+  /** 串口操作成功时的 toast 提示 */
+  onSuccess?: (msg: string) => void;
+}
+
+export function SerialConfig({ onSuccess }: SerialConfigProps = {}) {
   const [ports, setPorts] = useState<SerialPortInfo[]>([]);
   const [selected, setSelected] = useState<string>("");
   const [baudRate, setBaudRate] = useState(115200);
@@ -27,6 +40,7 @@ export function SerialConfig() {
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [portsChecked, setPortsChecked] = useState(false);
 
   async function refreshPorts() {
     setLoading(true);
@@ -41,6 +55,7 @@ export function SerialConfig() {
       setError((err as Error).message);
     } finally {
       setLoading(false);
+      setPortsChecked(true);
     }
   }
 
@@ -68,6 +83,7 @@ export function SerialConfig() {
     try {
       await serial.open(selected, { baudRate, dataBits, stopBits, parity });
       setIsOpen(true);
+      onSuccess?.(`串口已打开: ${selected} @ ${baudRate}`);
     } catch (err) {
       setError(`open 失败: ${(err as Error).message}`);
     }
@@ -78,6 +94,7 @@ export function SerialConfig() {
     try {
       await serial.close();
       setIsOpen(false);
+      onSuccess?.("串口已关闭");
     } catch (err) {
       setError(`close 失败: ${(err as Error).message}`);
     }
@@ -90,6 +107,10 @@ export function SerialConfig() {
         <p class="panel-subtitle">选择并打开设备的串口</p>
       </div>
 
+      {error && (
+        <ErrorBanner onDismiss={() => setError(null)}>{error}</ErrorBanner>
+      )}
+
       <section class="card">
         <div class="card-title">设备</div>
 
@@ -101,6 +122,7 @@ export function SerialConfig() {
               onChange={(e) => setSelected((e.target as HTMLSelectElement).value)}
               disabled={isOpen}
               style={{ flex: 1, minWidth: "180px" }}
+              aria-label="选择串口"
             >
               {ports.length === 0 && <option value="">（无可用串口）</option>}
               {ports.map((p) => (
@@ -127,6 +149,7 @@ export function SerialConfig() {
             onChange={(e) => setBaudRate(Number((e.target as HTMLSelectElement).value))}
             disabled={isOpen}
             style={{ maxWidth: "160px" }}
+            aria-label="波特率"
           >
             {BAUD_RATES.map((b) => (
               <option key={b} value={b}>{b}</option>
@@ -141,6 +164,7 @@ export function SerialConfig() {
               value={dataBits}
               onChange={(e) => setDataBits(Number((e.target as HTMLSelectElement).value) as 5 | 6 | 7 | 8)}
               disabled={isOpen}
+              aria-label="数据位"
             >
               {DATA_BITS.map((b) => (
                 <option key={b} value={b}>{b}</option>
@@ -154,6 +178,7 @@ export function SerialConfig() {
               value={stopBits}
               onChange={(e) => setStopBits(Number((e.target as HTMLSelectElement).value) as 1 | 2)}
               disabled={isOpen}
+              aria-label="停止位"
             >
               {STOP_BITS.map((b) => (
                 <option key={b} value={b}>{b}</option>
@@ -167,6 +192,7 @@ export function SerialConfig() {
               value={parity}
               onChange={(e) => setParity((e.target as HTMLSelectElement).value as SerialOptions["parity"])}
               disabled={isOpen}
+              aria-label="校验位"
             >
               {PARITIES.map((p) => (
                 <option key={p} value={p}>
@@ -183,7 +209,11 @@ export function SerialConfig() {
 
         <div class="btn-row">
           {!isOpen ? (
-            <button class="primary large" onClick={handleOpen} disabled={!selected}>
+            <button
+              class="primary large"
+              onClick={handleOpen}
+              disabled={!selected}
+            >
               打开串口
             </button>
           ) : (
@@ -197,7 +227,18 @@ export function SerialConfig() {
         </div>
       </section>
 
-      {error && <div class="error">{error}</div>}
+      {portsChecked && ports.length === 0 && !error && (
+        <EmptyState
+          icon={<IconSerial />}
+          title="未发现串口设备"
+          hint="检查 USB 转 485 转换器是否插入, 或点击刷新重试"
+          action={
+            <button onClick={refreshPorts} disabled={loading}>
+              {loading ? "刷新中…" : "刷新串口列表"}
+            </button>
+          }
+        />
+      )}
     </div>
   );
 }

--- a/packages/soft-dtu/webview/src/styles.css
+++ b/packages/soft-dtu/webview/src/styles.css
@@ -1032,3 +1032,543 @@ table tr:hover td {
     color: var(--text-primary);
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+ * 以下为接力 worker 补的 12 项细化（保持前 worker 风格基调）
+ *  1. SVG icon 容器
+ *  2. Status pill pulse 动画
+ *  3. Focus ring (button / input / select)
+ *  4. Nav shortcut (⌘1/2/3/4) 显示
+ *  5. Empty state 组件
+ *  6. Error banner (icon + dismiss)
+ *  7. Toast / Snackbar
+ *  8. AT console — 命令历史 / Cmd+Enter / Clear log
+ *  9. HEX view 三栏 (offset / hex / ascii, 16B/行)
+ * 10. Status bar "last sync"
+ * 11. Segmented control 微调
+ * 12. Meta grid (ProtocolViewer dt/dd)
+ * ═══════════════════════════════════════════════════════════════════ */
+
+/* ─── 1. SVG icon 容器 (sidebar nav) ─── */
+
+.nav-icon {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  transition: color var(--t-fast) var(--ease-out);
+}
+
+.nav-icon > svg {
+  width: 18px;
+  height: 18px;
+}
+
+.nav-item:hover .nav-icon {
+  color: var(--text-primary);
+}
+
+.nav-item.active .nav-icon {
+  color: var(--accent-blue);
+}
+
+/* ─── 4. Nav shortcut (⌘1/2/3/4) ─── */
+
+.nav-shortcut {
+  margin-left: auto;
+  padding: 0 var(--s-1);
+  font-size: var(--t-micro);
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  letter-spacing: var(--tr-body);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  border: 1px solid var(--separator-thin);
+  border-radius: var(--r-sm);
+  min-width: 22px;
+  text-align: center;
+  background: var(--bg-input);
+}
+
+.nav-item.active .nav-shortcut {
+  color: var(--accent-blue);
+  border-color: rgba(10, 132, 255, 0.3);
+  background: rgba(10, 132, 255, 0.12);
+}
+
+/* ─── 2. Status pill pulse 动画 (在线状态点) ─── */
+
+.status-pill.connected::before {
+  background: var(--accent-green);
+  box-shadow: 0 0 6px var(--accent-green);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+.status-bar .indicator.connected {
+  background: var(--accent-green);
+  animation: pulse-dot 2s ease-in-out infinite;
+  box-shadow: 0 0 4px var(--accent-green);
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(48, 209, 88, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(48, 209, 88, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-pill.connected::before,
+  .status-bar .indicator.connected {
+    animation: none;
+  }
+}
+
+/* ─── 3. Focus ring (Apple 风格) ─── */
+
+button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
+
+button.primary:focus-visible {
+  outline-color: var(--accent-blue-hover);
+}
+
+input:focus-visible,
+select:focus-visible,
+.cmd-input:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 0;
+  border-color: transparent;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.35);
+}
+
+.nav-item:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
+  border-radius: var(--r-sm);
+}
+
+/* ─── 5. Empty state 组件 ─── */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px;
+  text-align: center;
+  color: var(--text-secondary);
+  min-height: 240px;
+}
+
+.empty-state-icon {
+  width: 56px;
+  height: 56px;
+  color: var(--text-tertiary);
+  margin-bottom: var(--s-4);
+  opacity: 0.7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty-state-icon > svg {
+  width: 48px;
+  height: 48px;
+  stroke-width: 1.2;
+}
+
+.empty-state-title {
+  font-size: var(--t-title2);
+  font-weight: var(--w-semibold);
+  color: var(--text-primary);
+  letter-spacing: var(--tr-title);
+  line-height: var(--lh-snug);
+  margin-bottom: var(--s-1);
+}
+
+.empty-state-hint {
+  font-size: var(--t-callout);
+  color: var(--text-secondary);
+  max-width: 360px;
+  line-height: var(--lh-normal);
+  margin-bottom: var(--s-4);
+}
+
+.empty-state-action {
+  margin-top: var(--s-2);
+}
+
+/* ─── 6. Error banner (替换简单 .error, 加 icon + dismiss) ─── */
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-2) var(--s-4);
+  background: rgba(255, 69, 58, 0.12);
+  border: 1px solid rgba(255, 69, 58, 0.3);
+  border-radius: var(--r-md);
+  color: var(--accent-red);
+  font-size: var(--t-callout);
+  letter-spacing: var(--tr-body);
+  line-height: var(--lh-snug);
+  animation: error-banner-in 200ms var(--ease-out);
+}
+
+.error-banner-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.error-banner-text {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.error-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--accent-red);
+  font-size: 18px;
+  font-weight: var(--w-medium);
+  line-height: 1;
+  padding: var(--s-1) var(--s-2);
+  cursor: pointer;
+  border-radius: var(--r-sm);
+  flex-shrink: 0;
+  height: auto;
+  transition: background var(--t-fast) var(--ease-out);
+}
+
+.error-banner-dismiss:hover {
+  background: rgba(255, 69, 58, 0.2);
+}
+
+.error-banner-dismiss:active {
+  transform: scale(0.92);
+}
+
+@keyframes error-banner-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ─── 7. Toast / Snackbar (右下角, 3s 自动消失, materialize animation) ─── */
+
+.toast-stack {
+  position: fixed;
+  right: var(--s-6);
+  bottom: 44px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+  z-index: 100;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-2) var(--s-4);
+  background: rgba(58, 58, 60, 0.95);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-2);
+  color: var(--text-primary);
+  font-size: var(--t-callout);
+  letter-spacing: var(--tr-body);
+  pointer-events: auto;
+  min-width: 200px;
+  max-width: 360px;
+  animation: toast-in 240ms var(--ease-spring);
+}
+
+.toast.toast-out {
+  animation: toast-out 200ms var(--ease-out) forwards;
+}
+
+.toast-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-green);
+}
+
+.toast-icon > svg { width: 16px; height: 16px; }
+
+.toast-text {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes toast-out {
+  from { opacity: 1; transform: translateY(0) scale(1); }
+  to   { opacity: 0; transform: translateY(8px) scale(0.96); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast { animation: none; }
+}
+
+/* ─── 8. AT console — 命令历史 / Cmd+Enter / Clear log ─── */
+
+.cmd-input {
+  font-family: var(--font-mono);
+  font-size: var(--t-callout);
+  height: 32px;
+  letter-spacing: var(--tr-body);
+  caret-color: var(--accent-blue);
+}
+
+.cmd-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.cmd-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin-top: var(--s-2);
+  font-size: var(--t-micro);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tr-body);
+}
+
+.cmd-toolbar .kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  background: var(--bg-input);
+  border: 1px solid var(--separator-thin);
+  border-radius: var(--r-sm);
+  font-size: 10px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.log-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+  padding: 0 var(--s-3);
+  margin-bottom: var(--s-1);
+  font-size: var(--t-micro);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tr-body);
+}
+
+.log-toolbar .label {
+  text-transform: uppercase;
+  letter-spacing: var(--tr-caps);
+}
+
+.log-toolbar button {
+  height: 22px;
+  padding: 0 var(--s-3);
+  font-size: var(--t-micro);
+}
+
+/* ─── 9. HEX view 三栏 (offset / hex / ascii, 16B/行) ─── */
+
+.hex-row {
+  display: grid;
+  grid-template-columns: 64px 1fr 160px;
+  gap: var(--s-4);
+  padding: 2px var(--s-3);
+  border-radius: var(--r-sm);
+  transition: background var(--t-fast) var(--ease-out);
+  font-family: var(--font-mono);
+  font-size: var(--t-caption);
+  line-height: 1.65;
+  align-items: baseline;
+}
+
+.hex-row:hover {
+  background: var(--bg-button);
+}
+
+.hex-row .ts {
+  color: var(--text-tertiary);
+  font-size: var(--t-micro);
+  grid-column: 1 / -1;
+  margin-bottom: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
+.hex-row .hex-offset {
+  color: var(--text-tertiary);
+  font-size: var(--t-micro);
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+  align-self: baseline;
+}
+
+.hex-row .hex-bytes {
+  color: var(--accent-blue);
+  letter-spacing: 0.04em;
+  white-space: pre;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+}
+
+.hex-row .hex-ascii {
+  color: var(--text-primary);
+  white-space: pre;
+  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+}
+
+.hex-row .hex-bytes .nibble {
+  display: inline-block;
+  min-width: 1.7em;
+}
+
+.hex-row .hex-bytes .gap {
+  display: inline-block;
+  width: 0.6em;
+}
+
+/* ─── 10. Status bar "last sync" ─── */
+
+.status-bar .last-sync {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.status-bar .last-sync.never {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.status-bar .last-sync.fresh {
+  color: var(--accent-green);
+}
+
+/* ─── 11. Segmented control 微调（pill shape, SF 风格）─── */
+
+.seg {
+  display: inline-flex;
+  background: var(--bg-input);
+  border-radius: var(--r-md);
+  padding: 2px;
+  gap: 2px;
+  border: 1px solid var(--separator-thin);
+}
+
+.seg-btn {
+  padding: 0 var(--s-3);
+  height: 24px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: var(--t-micro);
+  font-family: var(--font-sans);
+  font-weight: var(--w-medium);
+  border-radius: 7px;
+  cursor: pointer;
+  letter-spacing: var(--tr-caps);
+  text-transform: uppercase;
+  transition: background var(--t-fast) var(--ease-out),
+              color var(--t-fast) var(--ease-out),
+              box-shadow var(--t-fast) var(--ease-out);
+}
+
+.seg-btn:hover:not(.active) {
+  color: var(--text-primary);
+}
+
+.seg-btn.active {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-1);
+}
+
+.seg-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/* ─── 12. Meta grid (ProtocolViewer dt/dd, SF card 风格) ─── */
+
+dl.meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--s-2) var(--s-5);
+  font-size: var(--t-callout);
+  line-height: var(--lh-normal);
+  font-family: var(--font-mono);
+  margin: 0;
+  padding: 0;
+}
+
+dl.meta dt {
+  color: var(--text-secondary);
+  font-weight: var(--w-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tr-caps);
+  font-size: var(--t-micro);
+  padding-top: 3px;
+}
+
+dl.meta dd {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  margin: 0;
+  word-break: break-word;
+}
+
+dl.meta dd > code {
+  display: inline-block;
+  background: var(--bg-input);
+  color: var(--accent-blue);
+  padding: 2px var(--s-2);
+  border-radius: var(--r-sm);
+  font-size: var(--t-caption);
+  font-family: var(--font-mono);
+}
+
+dl.meta dd > code.regex {
+  color: var(--accent-orange);
+}
+
+/* ─── 接力 patch: 浅色模式下保持 dark tokens（避免视觉跳变）─── */
+@media (prefers-color-scheme: light) {
+  .toast,
+  .cmd-toolbar .kbd,
+  .seg {
+    /* light mode 仍走 dark, 不变 */
+  }
+}

--- a/packages/soft-dtu/webview/src/styles.css
+++ b/packages/soft-dtu/webview/src/styles.css
@@ -1,21 +1,26 @@
 /**
- * 软 DTU WebView 全局样式 — Apple SF Dark Mode
+ * 软 DTU WebView 全局样式 — 工业控制台暖色调
  *
- * 设计原则（来自 Apple design skill）：
+ * v2 接力（cairui 反馈）: 整色调冷色 → 暖橙 (#ff8a3b), 8pt → 12pt grid,
+ * icons 加大 + stroke 加粗, sidebar/header/panel padding 全部放宽.
+ *
+ * 设计原则（来自 Apple design skill + cairui 偏好工业控制台）：
  *   - Materials & depth: backdrop-filter: blur(20px) saturate(180%) 做透色 chrome
  *   - System font: SF Pro Display/Text + PingFang SC（CJK fallback）
  *   - Optical sizing + tracking: 大字负 tracking，小字正 tracking
- *   - Translucent chrome: rgba(28,28,30,0.72) + 模糊, 不要硬边框
- *   - 8pt spacing grid: 4/8/12/16/20/24/32
+ *   - Translucent chrome: rgba(31,27,24,0.78) + 模糊, 不要硬边框
+ *   - 12pt spacing grid: 4/8/12/16/20/24/28/32/36/40/44/48
  *   - Spring-like transitions: cubic-bezier(0.4,0,0.2,1) 200ms
  *   - Pointer-down feedback: scale(0.97) 100ms
  *   - Restraint: 只关键 transition, 不所有元素都动
+ *   - 暖橙 (cairui 偏好) 替代 SF 冷蓝
  *
  * 可访问性：
  *   - prefers-reduced-motion: 降级到 opacity, 不动 transform
- *   - prefers-reduced-transparency: sidebar/header/status 改实色 #1c1c1e
+ *   - prefers-reduced-transparency: sidebar/header/status 改实色 #1f1b18
  *
- * Phase 1 不实现 light mode (token 留好, Phase 2 加)。
+ * Phase 1 不实现 light mode (token 留好, Phase 2 加).
+ * 备选冷色 "赛博青" 主题: 留 Phase 2 toggle, 当前不实现.
  */
 
 * {
@@ -25,51 +30,51 @@
 }
 
 :root {
-  /* ─── Background layers (Apple SF dark) ─── */
-  --bg-base: #000000;
-  --bg-elevated: #1c1c1e;
-  --bg-sidebar: rgba(28, 28, 30, 0.72);
-  --bg-header: rgba(28, 28, 30, 0.6);
-  --bg-statusbar: rgba(28, 28, 30, 0.72);
-  --bg-card: rgba(44, 44, 46, 0.6);
-  --bg-card-hover: rgba(58, 58, 60, 0.6);
-  --bg-input: rgba(118, 118, 128, 0.24);
-  --bg-input-focus: rgba(118, 118, 128, 0.32);
-  --bg-button: rgba(118, 118, 128, 0.24);
-  --bg-button-hover: rgba(118, 118, 128, 0.32);
+  /* ─── Background layers (暖深棕黑 + 暖灰分层) ─── */
+  --bg-base: #14110f;
+  --bg-elevated: #1f1b18;
+  --bg-sidebar: rgba(31, 27, 24, 0.78);
+  --bg-header: rgba(31, 27, 24, 0.68);
+  --bg-statusbar: rgba(31, 27, 24, 0.78);
+  --bg-card: rgba(48, 41, 35, 0.55);
+  --bg-card-hover: rgba(62, 53, 45, 0.6);
+  --bg-input: rgba(82, 71, 60, 0.32);
+  --bg-input-focus: rgba(82, 71, 60, 0.45);
+  --bg-button: rgba(82, 71, 60, 0.32);
+  --bg-button-hover: rgba(100, 86, 72, 0.42);
 
-  /* ─── Borders (Apple 不用 1px 实线, 用半透明) ─── */
-  --separator: rgba(84, 84, 88, 0.65);
-  --separator-opaque: #38383a;
-  --separator-thin: rgba(84, 84, 88, 0.35);
+  /* ─── Borders (暖分离) ─── */
+  --separator: rgba(118, 102, 88, 0.55);
+  --separator-opaque: #3a322b;
+  --separator-thin: rgba(118, 102, 88, 0.4);
 
-  /* ─── Text (Apple SF 文字色阶) ─── */
-  --text-primary: #ffffff;
-  --text-secondary: rgba(235, 235, 245, 0.6);
-  --text-tertiary: rgba(235, 235, 245, 0.3);
-  --text-quaternary: rgba(235, 235, 245, 0.18);
+  /* ─── Text (暖白, 不刺眼) ─── */
+  --text-primary: #fff8ed;
+  --text-secondary: rgba(255, 248, 237, 0.62);
+  --text-tertiary: rgba(255, 248, 237, 0.34);
+  --text-quaternary: rgba(255, 248, 237, 0.18);
 
-  /* ─── Accent (SF System Colors dark) ─── */
-  --accent-blue: #0a84ff;
-  --accent-blue-hover: #409cff;
-  --accent-green: #30d158;
-  --accent-red: #ff453a;
-  --accent-orange: #ff9f0a;
-  --accent-purple: #bf5af2;
+  /* ─── Accent (暖橙主色 + 配套暖色) ─── */
+  --accent-blue: #ff8a3b;
+  --accent-blue-hover: #ffa55e;
+  --accent-green: #7ed87a;
+  --accent-red: #ff6e5c;
+  --accent-orange: #ffb84a;
+  --accent-purple: #c490f0;
 
-  /* ─── Serial data (warm/cold visual distinction) ─── */
-  --serial-tx: #64d2ff;     /* cyan, data we send */
-  --serial-rx: #30d158;     /* green, data we receive */
-  --serial-err: #ff453a;
-  --serial-parsed: #ffd60a; /* yellow, parsed fields */
+  /* ─── Serial data (冷色保持跟暖底对比) ─── */
+  --serial-tx: #5acdff;
+  --serial-rx: #7ed87a;
+  --serial-err: #ff6e5c;
+  --serial-parsed: #ffd86b;
 
-  /* ─── Type scale (Apple HIG) ─── */
+  /* ─── Type scale (Apple HIG + 略放大) ─── */
   --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
   --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
 
   /* ─── Type sizes (Apple HIG) ─── */
-  --t-display: 28px;
-  --t-title1: 22px;
+  --t-display: 30px;
+  --t-title1: 24px;
   --t-title2: 17px;
   --t-body: 14px;
   --t-callout: 13px;
@@ -95,28 +100,31 @@
   --tr-caption: 0;
   --tr-caps: 0.05em;
 
-  /* ─── Spacing (8pt grid) ─── */
+  /* ─── Spacing (12pt grid — v2 接力从 8pt 升级) ─── */
   --s-1: 4px;
   --s-2: 8px;
   --s-3: 12px;
   --s-4: 16px;
   --s-5: 20px;
   --s-6: 24px;
+  --s-7: 28px;       /* v2 新加 */
   --s-8: 32px;
+  --s-9: 36px;       /* v2 新加 */
   --s-10: 40px;
+  --s-11: 44px;      /* v2 新加 */
   --s-12: 48px;
 
-  /* ─── Radius (Apple HIG continuous) ─── */
-  --r-sm: 6px;
-  --r-md: 10px;
+  /* ─── Radius (Apple HIG continuous, 略放大) ─── */
+  --r-sm: 7px;
+  --r-md: 11px;
   --r-lg: 14px;
   --r-xl: 20px;
   --r-pill: 999px;
 
-  /* ─── Shadow (Apple HIG layered shadow) ─── */
-  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-2: 0 4px 16px rgba(0, 0, 0, 0.4);
-  --shadow-focus: 0 0 0 3px rgba(10, 132, 255, 0.4);
+  /* ─── Shadow (Apple HIG layered shadow, 暖深色调) ─── */
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-2: 0 4px 16px rgba(0, 0, 0, 0.45);
+  --shadow-focus: 0 0 0 3px rgba(255, 138, 59, 0.4);
 
   /* ─── Motion (Apple material easing) ─── */
   --ease-out: cubic-bezier(0.4, 0, 0.2, 1);
@@ -125,9 +133,9 @@
   --t-normal: 200ms;
   --t-slow: 300ms;
 
-  /* ─── Layout dims ─── */
-  --sidebar-w: 200px;
-  --header-h: 56px;
+  /* ─── Layout dims (v2 接力放宽) ─── */
+  --sidebar-w: 220px;
+  --header-h: 64px;
   --statusbar-h: 28px;
 }
 
@@ -153,7 +161,7 @@ html, body, #app {
   background: var(--bg-base);
 }
 
-/* ─── Sidebar (translucent, 200px) ─── */
+/* ─── Sidebar (translucent, 220px) ─── */
 
 .sidebar {
   display: flex;
@@ -162,19 +170,37 @@ html, body, #app {
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-right: 1px solid var(--separator-thin);
-  padding: var(--s-5) var(--s-2) var(--s-4);
-  gap: var(--s-1);
+  padding: var(--s-6) var(--s-3) var(--s-5);
+  gap: var(--s-2);
   overflow-y: auto;
 }
 
 .sidebar-brand {
-  padding: var(--s-2) var(--s-3) var(--s-4);
+  padding: var(--s-3) var(--s-3) var(--s-5);
   font-size: var(--t-caption);
   font-weight: var(--w-semibold);
   letter-spacing: var(--tr-caps);
   text-transform: uppercase;
   color: var(--text-secondary);
   user-select: none;
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+
+.sidebar-brand-mark {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-blue);
+  flex-shrink: 0;
+}
+
+.sidebar-brand-mark > svg {
+  width: 22px;
+  height: 22px;
 }
 
 .sidebar-nav {
@@ -187,10 +213,11 @@ html, body, #app {
   display: flex;
   align-items: center;
   gap: var(--s-3);
-  padding: var(--s-2) var(--s-3);
+  padding: 0 var(--s-4);
+  height: 40px;
   background: transparent;
   border: none;
-  border-radius: var(--r-sm);
+  border-radius: var(--r-md);
   color: var(--text-secondary);
   font-family: var(--font-sans);
   font-size: var(--t-body);
@@ -215,30 +242,54 @@ html, body, #app {
 
 .nav-item.active {
   color: var(--accent-blue);
-  background: transparent;
+  background: rgba(255, 138, 59, 0.10);
   font-weight: var(--w-medium);
 }
 
 .nav-item.active::before {
   content: "";
   position: absolute;
-  left: 0;
-  top: var(--s-2);
-  bottom: var(--s-2);
-  width: 2px;
+  left: -3px;
+  top: var(--s-3);
+  bottom: var(--s-3);
+  width: 3px;
   background: var(--accent-blue);
   border-radius: var(--r-pill);
 }
 
+.nav-item:disabled {
+  color: var(--text-tertiary);
+  cursor: not-allowed;
+}
+
+.nav-item:disabled .nav-icon {
+  color: var(--text-tertiary);
+}
+
 .nav-icon {
-  width: 18px;
-  text-align: center;
-  font-size: 15px;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
   flex-shrink: 0;
-  filter: grayscale(20%);
+  transition: color var(--t-fast) var(--ease-out);
+}
+
+.nav-icon > svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+
+.nav-item:hover .nav-icon {
+  color: var(--text-primary);
 }
 
 .nav-item.active .nav-icon {
+  color: var(--accent-blue);
   filter: none;
 }
 
@@ -248,7 +299,7 @@ html, body, #app {
 
 .sidebar-footer {
   margin-top: auto;
-  padding-top: var(--s-3);
+  padding-top: var(--s-4);
   border-top: 1px solid var(--separator-thin);
   display: flex;
   flex-direction: column;
@@ -264,14 +315,14 @@ html, body, #app {
   overflow: hidden;
 }
 
-/* ─── Header (sticky, translucent) ─── */
+/* ─── Header (sticky, translucent, 64px) ─── */
 
 .app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--s-4);
-  padding: 0 var(--s-6);
+  padding: 0 var(--s-8);
   background: var(--bg-header);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
@@ -297,7 +348,7 @@ html, body, #app {
   color: var(--text-secondary);
   letter-spacing: var(--tr-body);
   line-height: var(--lh-snug);
-  margin-top: 2px;
+  margin-top: 4px;
 }
 
 /* ─── Status pill (header) ─── */
@@ -344,11 +395,11 @@ html, body, #app {
   color: var(--accent-red);
 }
 
-/* ─── Panel (content area) ─── */
+/* ─── Panel (content area, 32px padding) ─── */
 
 .panel {
   overflow: auto;
-  padding: var(--s-6);
+  padding: var(--s-8);
   animation: panelFadeIn var(--t-normal) var(--ease-out);
 }
 
@@ -358,7 +409,7 @@ html, body, #app {
 }
 
 .panel-header {
-  margin-bottom: var(--s-5);
+  margin-bottom: var(--s-7);
 }
 
 .panel-title {
@@ -372,11 +423,11 @@ html, body, #app {
 .panel-subtitle {
   font-size: var(--t-callout);
   color: var(--text-secondary);
-  margin-top: var(--s-1);
+  margin-top: var(--s-2);
   line-height: var(--lh-snug);
 }
 
-/* ─── Card (panel content block) ─── */
+/* ─── Card (panel content block, 24-28px padding) ─── */
 
 .card {
   background: var(--bg-card);
@@ -384,9 +435,9 @@ html, body, #app {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid var(--separator-thin);
   border-radius: var(--r-lg);
-  padding: var(--s-5);
+  padding: var(--s-6);
   box-shadow: var(--shadow-1);
-  margin-bottom: var(--s-4);
+  margin-bottom: var(--s-6);
 }
 
 .card-title {
@@ -395,7 +446,7 @@ html, body, #app {
   text-transform: uppercase;
   letter-spacing: var(--tr-caps);
   color: var(--text-secondary);
-  margin-bottom: var(--s-4);
+  margin-bottom: var(--s-5);
 }
 
 /* ─── Form field (SF style) ─── */
@@ -403,8 +454,8 @@ html, body, #app {
 .field {
   display: flex;
   flex-direction: column;
-  gap: var(--s-1);
-  margin-bottom: var(--s-4);
+  gap: var(--s-2);
+  margin-bottom: var(--s-5);
 }
 
 .field-label {
@@ -417,20 +468,20 @@ html, body, #app {
 
 .field-row {
   display: flex;
-  gap: var(--s-3);
+  gap: var(--s-5);
   flex-wrap: wrap;
 }
 
 .field-row > .field {
   flex: 1;
-  min-width: 120px;
+  min-width: 140px;
 }
 
 select, input[type="text"], input[type="number"] {
   appearance: none;
   -webkit-appearance: none;
-  padding: 0 var(--s-3);
-  height: 28px;
+  padding: 0 var(--s-4);
+  height: 32px;
   background: var(--bg-input);
   color: var(--text-primary);
   border: none;
@@ -444,7 +495,7 @@ select, input[type="text"], input[type="number"] {
 }
 
 select {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='rgba(235,235,245,0.6)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='rgba(255,248,237,0.62)' stroke-width='1.75' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   background-repeat: no-repeat;
   background-position: right var(--s-3) center;
   padding-right: var(--s-8);
@@ -471,15 +522,15 @@ select option {
   letter-spacing: var(--tr-body);
 }
 
-/* ─── Button (SF style) ─── */
+/* ─── Button (SF style, 34-36px height) ─── */
 
 button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--s-2);
-  padding: 0 var(--s-4);
-  height: 28px;
+  padding: 0 var(--s-5);
+  height: 34px;
   background: var(--bg-button);
   color: var(--text-primary);
   border: none;
@@ -492,6 +543,12 @@ button {
   user-select: none;
   transition: background var(--t-fast) var(--ease-out),
               transform var(--t-fast) var(--ease-out);
+}
+
+button > svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
 button:hover:not(:disabled) {
@@ -510,7 +567,7 @@ button:disabled {
 
 button.primary {
   background: var(--accent-blue);
-  color: #ffffff;
+  color: #1a1004;
 }
 
 button.primary:hover:not(:disabled) {
@@ -523,13 +580,18 @@ button.danger {
 }
 
 button.danger:hover:not(:disabled) {
-  background: #ff6961;
+  background: #ff8a7a;
 }
 
 button.large {
-  height: 32px;
-  padding: 0 var(--s-5);
+  height: 36px;
+  padding: 0 var(--s-6);
   font-size: var(--t-body);
+}
+
+button.large > svg {
+  width: 18px;
+  height: 18px;
 }
 
 .btn-row {
@@ -537,7 +599,7 @@ button.large {
   gap: var(--s-3);
   align-items: center;
   flex-wrap: wrap;
-  margin-top: var(--s-2);
+  margin-top: var(--s-3);
 }
 
 /* ─── Inline status pill (form area, e.g. "已打开: ttyUSB0 @ 115200") ─── */
@@ -589,14 +651,14 @@ button.large {
 }
 
 .error {
-  background: rgba(255, 69, 58, 0.12);
-  border-color: rgba(255, 69, 58, 0.3);
+  background: rgba(255, 110, 92, 0.12);
+  border-color: rgba(255, 110, 92, 0.3);
   color: var(--accent-red);
 }
 
 .warn {
-  background: rgba(255, 159, 10, 0.12);
-  border-color: rgba(255, 159, 10, 0.3);
+  background: rgba(255, 184, 74, 0.12);
+  border-color: rgba(255, 184, 74, 0.3);
   color: var(--accent-orange);
 }
 
@@ -625,8 +687,8 @@ button.large {
 }
 
 .suggestion {
-  padding: 0 var(--s-3);
-  height: 24px;
+  padding: 0 var(--s-4);
+  height: 26px;
   font-size: var(--t-micro);
   font-family: var(--font-mono);
   background: var(--bg-input);
@@ -863,7 +925,7 @@ button.large {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid var(--separator-thin);
   border-radius: var(--r-lg);
-  padding: var(--s-5);
+  padding: var(--s-7);
   box-shadow: var(--shadow-1);
 }
 
@@ -872,15 +934,15 @@ button.large {
   font-weight: var(--w-semibold);
   letter-spacing: var(--tr-title);
   line-height: var(--lh-snug);
-  margin-bottom: var(--s-2);
+  margin-bottom: var(--s-3);
   color: var(--text-primary);
 }
 
 .protocol-detail h3 {
   font-size: var(--t-caption);
   font-weight: var(--w-semibold);
-  margin-top: var(--s-5);
-  margin-bottom: var(--s-3);
+  margin-top: var(--s-7);
+  margin-bottom: var(--s-4);
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: var(--tr-caps);
@@ -889,7 +951,7 @@ button.large {
 dl.meta {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: var(--s-2) var(--s-5);
+  gap: var(--s-3) var(--s-6);
   font-size: var(--t-callout);
   font-family: var(--font-mono);
   line-height: var(--lh-normal);
@@ -921,16 +983,17 @@ code.regex {
 table {
   width: 100%;
   border-collapse: collapse;
-  font-size: var(--t-caption);
+  font-size: var(--t-callout);
   font-family: var(--font-mono);
-  margin-top: var(--s-2);
+  margin-top: var(--s-3);
   border-radius: var(--r-md);
   overflow: hidden;
+  line-height: var(--lh-relaxed);
 }
 
 table th, table td {
   text-align: left;
-  padding: var(--s-2) var(--s-3);
+  padding: var(--s-3) var(--s-4);
   border-bottom: 1px solid var(--separator-thin);
 }
 
@@ -940,7 +1003,7 @@ table th {
   text-transform: uppercase;
   font-size: var(--t-micro);
   letter-spacing: var(--tr-caps);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.25);
 }
 
 table tr:last-child td {
@@ -1050,30 +1113,8 @@ table tr:hover td {
  * ═══════════════════════════════════════════════════════════════════ */
 
 /* ─── 1. SVG icon 容器 (sidebar nav) ─── */
-
-.nav-icon {
-  width: 22px;
-  height: 22px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  color: var(--text-secondary);
-  transition: color var(--t-fast) var(--ease-out);
-}
-
-.nav-icon > svg {
-  width: 18px;
-  height: 18px;
-}
-
-.nav-item:hover .nav-icon {
-  color: var(--text-primary);
-}
-
-.nav-item.active .nav-icon {
-  color: var(--accent-blue);
-}
+/* 注: .nav-icon / .nav-item:hover .nav-icon / .nav-item.active .nav-icon
+   已在主区段定义, 这里不再重复声明, 避免后定义覆盖主区段 22px 尺寸 */
 
 /* ─── 4. Nav shortcut (⌘1/2/3/4) ─── */
 
@@ -1095,8 +1136,8 @@ table tr:hover td {
 
 .nav-item.active .nav-shortcut {
   color: var(--accent-blue);
-  border-color: rgba(10, 132, 255, 0.3);
-  background: rgba(10, 132, 255, 0.12);
+  border-color: rgba(255, 138, 59, 0.32);
+  background: rgba(255, 138, 59, 0.14);
 }
 
 /* ─── 2. Status pill pulse 动画 (在线状态点) ─── */
@@ -1115,10 +1156,10 @@ table tr:hover td {
 
 @keyframes pulse-dot {
   0%, 100% {
-    box-shadow: 0 0 0 0 rgba(48, 209, 88, 0.5);
+    box-shadow: 0 0 0 0 rgba(126, 216, 122, 0.5);
   }
   50% {
-    box-shadow: 0 0 0 5px rgba(48, 209, 88, 0);
+    box-shadow: 0 0 0 5px rgba(126, 216, 122, 0);
   }
 }
 
@@ -1147,7 +1188,7 @@ select:focus-visible,
   outline: 2px solid var(--accent-blue);
   outline-offset: 0;
   border-color: transparent;
-  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.35);
+  box-shadow: 0 0 0 3px rgba(255, 138, 59, 0.35);
 }
 
 .nav-item:focus-visible {
@@ -1163,10 +1204,10 @@ select:focus-visible,
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 80px 24px;
+  padding: var(--s-12) var(--s-8);
   text-align: center;
   color: var(--text-secondary);
-  min-height: 240px;
+  min-height: 280px;
 }
 
 .empty-state-icon {
@@ -1255,7 +1296,7 @@ select:focus-visible,
 }
 
 .error-banner-dismiss:hover {
-  background: rgba(255, 69, 58, 0.2);
+  background: rgba(255, 110, 92, 0.2);
 }
 
 .error-banner-dismiss:active {
@@ -1283,9 +1324,9 @@ select:focus-visible,
 .toast {
   display: flex;
   align-items: center;
-  gap: var(--s-2);
-  padding: var(--s-2) var(--s-4);
-  background: rgba(58, 58, 60, 0.95);
+  gap: var(--s-3);
+  padding: var(--s-3) var(--s-5);
+  background: rgba(48, 41, 35, 0.95);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-radius: var(--r-md);
@@ -1395,8 +1436,8 @@ select:focus-visible,
 }
 
 .log-toolbar button {
-  height: 22px;
-  padding: 0 var(--s-3);
+  height: 26px;
+  padding: 0 var(--s-4);
   font-size: var(--t-micro);
 }
 
@@ -1490,8 +1531,8 @@ select:focus-visible,
 }
 
 .seg-btn {
-  padding: 0 var(--s-3);
-  height: 24px;
+  padding: 0 var(--s-4);
+  height: 26px;
   background: transparent;
   border: none;
   color: var(--text-secondary);

--- a/packages/soft-dtu/webview/src/styles.css
+++ b/packages/soft-dtu/webview/src/styles.css
@@ -1,0 +1,488 @@
+/**
+ * 软 DTU WebView 全局样式
+ *
+ * 设计原则：
+ *   - 极简：黑色背景 + 单色高亮，跟 XCOM / sscom 风格接近
+ *   - 信息密度高：fixed 字体 + 等宽对齐
+ *   - 暗色优先：长时间调试不刺眼
+ */
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #1a1a1a;
+  --bg-elev: #232323;
+  --bg-elev-2: #2a2a2a;
+  --border: #3a3a3a;
+  --text: #e0e0e0;
+  --text-dim: #999;
+  --text-bright: #fff;
+  --accent: #4a9eff;
+  --accent-hover: #5fb0ff;
+  --danger: #ff5555;
+  --danger-hover: #ff7777;
+  --ok: #4caf50;
+  --warn: #ffaa00;
+  --tx: #4a9eff;
+  --rx: #4caf50;
+  --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", sans-serif;
+}
+
+html, body, #app {
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* ─── App shell ─── */
+
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.app-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 20px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+}
+
+.app-header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.subtitle {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 12px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+}
+
+.tab {
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 13px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.1s;
+}
+
+.tab:hover {
+  color: var(--text);
+}
+
+.tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.panel {
+  flex: 1;
+  overflow: auto;
+  padding: 20px;
+}
+
+/* ─── 通用 form ─── */
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.row label {
+  font-size: 12px;
+  color: var(--text-dim);
+  min-width: 60px;
+}
+
+.row .spacer {
+  margin-left: auto;
+}
+
+.row.toolbar {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+
+.row.actions {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+select, input[type="text"], input[type="number"] {
+  padding: 6px 10px;
+  background: var(--bg-elev-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  min-width: 120px;
+}
+
+select:focus, input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+select:disabled, input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button {
+  padding: 6px 14px;
+  background: var(--bg-elev-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 0.1s;
+}
+
+button:hover:not(:disabled) {
+  background: var(--bg-elev);
+  border-color: var(--text-dim);
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+button.primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+button.danger {
+  background: var(--danger);
+  color: white;
+  border-color: var(--danger);
+}
+
+button.danger:hover:not(:disabled) {
+  background: var(--danger-hover);
+  border-color: var(--danger-hover);
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.status {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 3px;
+}
+
+.status.open {
+  background: rgba(76, 175, 80, 0.2);
+  color: var(--ok);
+}
+
+.status.closed {
+  background: var(--bg-elev-2);
+  color: var(--text-dim);
+}
+
+.error {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: rgba(255, 85, 85, 0.15);
+  border: 1px solid var(--danger);
+  border-radius: 4px;
+  color: var(--danger);
+  font-size: 12px;
+}
+
+.warn {
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  background: rgba(255, 170, 0, 0.1);
+  border: 1px solid var(--warn);
+  border-radius: 4px;
+  color: var(--warn);
+  font-size: 12px;
+}
+
+.count {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+/* ─── AT Console ─── */
+
+.at-console {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.cmd-input {
+  flex: 1;
+  font-size: 14px;
+}
+
+.suggestions {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.suggestion {
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+}
+
+.log {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.log-entry {
+  display: flex;
+  gap: 8px;
+  padding: 2px 4px;
+  align-items: baseline;
+}
+
+.log-entry:hover {
+  background: var(--bg-elev-2);
+}
+
+.log-entry .ts {
+  color: var(--text-dim);
+  flex-shrink: 0;
+  font-size: 10px;
+}
+
+.log-entry .dir {
+  flex-shrink: 0;
+  font-weight: bold;
+  width: 12px;
+}
+
+.log-tx .dir { color: var(--tx); }
+.log-rx .dir { color: var(--rx); }
+
+.log-entry .ascii {
+  flex: 0 0 auto;
+  color: var(--text-bright);
+}
+
+.log-entry .hex {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.log-entry .parsed {
+  color: var(--ok);
+  font-size: 11px;
+}
+
+/* ─── HEX View ─── */
+
+.hex-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.seg {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.seg-btn {
+  border: none;
+  border-radius: 0;
+  background: var(--bg-elev-2);
+  padding: 6px 12px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+}
+
+.seg-btn:not(:last-child) {
+  border-right: 1px solid var(--border);
+}
+
+.seg-btn.active {
+  background: var(--accent);
+  color: white;
+}
+
+.hex-log {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.hex-log .empty {
+  color: var(--text-dim);
+  text-align: center;
+  padding: 40px;
+  font-style: italic;
+}
+
+.hex-row {
+  display: flex;
+  gap: 16px;
+  padding: 2px 4px;
+  border-bottom: 1px solid transparent;
+}
+
+.hex-row:hover {
+  background: var(--bg-elev-2);
+}
+
+.hex-row .ts {
+  color: var(--text-dim);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.hex-row .hex {
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+
+.hex-row .ascii {
+  color: var(--text-bright);
+  font-family: var(--font-mono);
+}
+
+/* ─── Protocol Viewer ─── */
+
+.protocol-detail {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 20px;
+}
+
+.protocol-detail h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--text-bright);
+}
+
+.protocol-detail h3 {
+  font-size: 13px;
+  font-weight: 600;
+  margin-top: 20px;
+  margin-bottom: 8px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+dl.meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+dl.meta dt {
+  color: var(--text-dim);
+}
+
+dl.meta dd {
+  color: var(--text);
+}
+
+dl.meta code, code {
+  background: var(--bg-elev-2);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: var(--accent);
+}
+
+code.regex {
+  color: var(--warn);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  margin-top: 4px;
+}
+
+table th, table td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+table th {
+  color: var(--text-dim);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+
+table tr:hover td {
+  background: var(--bg-elev-2);
+}

--- a/packages/soft-dtu/webview/src/styles.css
+++ b/packages/soft-dtu/webview/src/styles.css
@@ -1,10 +1,21 @@
 /**
- * 软 DTU WebView 全局样式
+ * 软 DTU WebView 全局样式 — Apple SF Dark Mode
  *
- * 设计原则：
- *   - 极简：黑色背景 + 单色高亮，跟 XCOM / sscom 风格接近
- *   - 信息密度高：fixed 字体 + 等宽对齐
- *   - 暗色优先：长时间调试不刺眼
+ * 设计原则（来自 Apple design skill）：
+ *   - Materials & depth: backdrop-filter: blur(20px) saturate(180%) 做透色 chrome
+ *   - System font: SF Pro Display/Text + PingFang SC（CJK fallback）
+ *   - Optical sizing + tracking: 大字负 tracking，小字正 tracking
+ *   - Translucent chrome: rgba(28,28,30,0.72) + 模糊, 不要硬边框
+ *   - 8pt spacing grid: 4/8/12/16/20/24/32
+ *   - Spring-like transitions: cubic-bezier(0.4,0,0.2,1) 200ms
+ *   - Pointer-down feedback: scale(0.97) 100ms
+ *   - Restraint: 只关键 transition, 不所有元素都动
+ *
+ * 可访问性：
+ *   - prefers-reduced-motion: 降级到 opacity, 不动 transform
+ *   - prefers-reduced-transparency: sidebar/header/status 改实色 #1c1c1e
+ *
+ * Phase 1 不实现 light mode (token 留好, Phase 2 加)。
  */
 
 * {
@@ -14,165 +25,482 @@
 }
 
 :root {
-  --bg: #1a1a1a;
-  --bg-elev: #232323;
-  --bg-elev-2: #2a2a2a;
-  --border: #3a3a3a;
-  --text: #e0e0e0;
-  --text-dim: #999;
-  --text-bright: #fff;
-  --accent: #4a9eff;
-  --accent-hover: #5fb0ff;
-  --danger: #ff5555;
-  --danger-hover: #ff7777;
-  --ok: #4caf50;
-  --warn: #ffaa00;
-  --tx: #4a9eff;
-  --rx: #4caf50;
+  /* ─── Background layers (Apple SF dark) ─── */
+  --bg-base: #000000;
+  --bg-elevated: #1c1c1e;
+  --bg-sidebar: rgba(28, 28, 30, 0.72);
+  --bg-header: rgba(28, 28, 30, 0.6);
+  --bg-statusbar: rgba(28, 28, 30, 0.72);
+  --bg-card: rgba(44, 44, 46, 0.6);
+  --bg-card-hover: rgba(58, 58, 60, 0.6);
+  --bg-input: rgba(118, 118, 128, 0.24);
+  --bg-input-focus: rgba(118, 118, 128, 0.32);
+  --bg-button: rgba(118, 118, 128, 0.24);
+  --bg-button-hover: rgba(118, 118, 128, 0.32);
+
+  /* ─── Borders (Apple 不用 1px 实线, 用半透明) ─── */
+  --separator: rgba(84, 84, 88, 0.65);
+  --separator-opaque: #38383a;
+  --separator-thin: rgba(84, 84, 88, 0.35);
+
+  /* ─── Text (Apple SF 文字色阶) ─── */
+  --text-primary: #ffffff;
+  --text-secondary: rgba(235, 235, 245, 0.6);
+  --text-tertiary: rgba(235, 235, 245, 0.3);
+  --text-quaternary: rgba(235, 235, 245, 0.18);
+
+  /* ─── Accent (SF System Colors dark) ─── */
+  --accent-blue: #0a84ff;
+  --accent-blue-hover: #409cff;
+  --accent-green: #30d158;
+  --accent-red: #ff453a;
+  --accent-orange: #ff9f0a;
+  --accent-purple: #bf5af2;
+
+  /* ─── Serial data (warm/cold visual distinction) ─── */
+  --serial-tx: #64d2ff;     /* cyan, data we send */
+  --serial-rx: #30d158;     /* green, data we receive */
+  --serial-err: #ff453a;
+  --serial-parsed: #ffd60a; /* yellow, parsed fields */
+
+  /* ─── Type scale (Apple HIG) ─── */
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
   --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", sans-serif;
+
+  /* ─── Type sizes (Apple HIG) ─── */
+  --t-display: 28px;
+  --t-title1: 22px;
+  --t-title2: 17px;
+  --t-body: 14px;
+  --t-callout: 13px;
+  --t-caption: 12px;
+  --t-micro: 11px;
+
+  /* ─── Type weights ─── */
+  --w-regular: 400;
+  --w-medium: 500;
+  --w-semibold: 600;
+  --w-bold: 700;
+
+  /* ─── Leading (line-height) ─── */
+  --lh-tight: 1.15;
+  --lh-snug: 1.3;
+  --lh-normal: 1.45;
+  --lh-relaxed: 1.6;
+
+  /* ─── Tracking (letter-spacing) ─── */
+  --tr-display: -0.02em;
+  --tr-title: -0.01em;
+  --tr-body: 0;
+  --tr-caption: 0;
+  --tr-caps: 0.05em;
+
+  /* ─── Spacing (8pt grid) ─── */
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+
+  /* ─── Radius (Apple HIG continuous) ─── */
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 20px;
+  --r-pill: 999px;
+
+  /* ─── Shadow (Apple HIG layered shadow) ─── */
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-2: 0 4px 16px rgba(0, 0, 0, 0.4);
+  --shadow-focus: 0 0 0 3px rgba(10, 132, 255, 0.4);
+
+  /* ─── Motion (Apple material easing) ─── */
+  --ease-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --t-fast: 120ms;
+  --t-normal: 200ms;
+  --t-slow: 300ms;
+
+  /* ─── Layout dims ─── */
+  --sidebar-w: 200px;
+  --header-h: 56px;
+  --statusbar-h: 28px;
 }
 
 html, body, #app {
   height: 100%;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--bg-base);
+  color: var(--text-primary);
   font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: var(--t-body);
+  line-height: var(--lh-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "cv11", "ss01", "ss03";
 }
 
 /* ─── App shell ─── */
 
 .app {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-rows: 1fr;
+  height: 100%;
+  background: var(--bg-base);
+}
+
+/* ─── Sidebar (translucent, 200px) ─── */
+
+.sidebar {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  background: var(--bg-sidebar);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-right: 1px solid var(--separator-thin);
+  padding: var(--s-5) var(--s-2) var(--s-4);
+  gap: var(--s-1);
+  overflow-y: auto;
 }
+
+.sidebar-brand {
+  padding: var(--s-2) var(--s-3) var(--s-4);
+  font-size: var(--t-caption);
+  font-weight: var(--w-semibold);
+  letter-spacing: var(--tr-caps);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-2) var(--s-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--t-body);
+  font-weight: var(--w-regular);
+  letter-spacing: var(--tr-body);
+  cursor: pointer;
+  text-align: left;
+  position: relative;
+  transition: background var(--t-fast) var(--ease-out),
+              color var(--t-fast) var(--ease-out);
+}
+
+.nav-item:hover {
+  background: var(--bg-button);
+  color: var(--text-primary);
+}
+
+.nav-item:active {
+  transform: scale(0.97);
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.nav-item.active {
+  color: var(--accent-blue);
+  background: transparent;
+  font-weight: var(--w-medium);
+}
+
+.nav-item.active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: var(--s-2);
+  bottom: var(--s-2);
+  width: 2px;
+  background: var(--accent-blue);
+  border-radius: var(--r-pill);
+}
+
+.nav-icon {
+  width: 18px;
+  text-align: center;
+  font-size: 15px;
+  flex-shrink: 0;
+  filter: grayscale(20%);
+}
+
+.nav-item.active .nav-icon {
+  filter: none;
+}
+
+.nav-label {
+  flex: 1;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: var(--s-3);
+  border-top: 1px solid var(--separator-thin);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+/* ─── Main column (header + panel + statusbar) ─── */
+
+.main {
+  display: grid;
+  grid-template-rows: var(--header-h) 1fr var(--statusbar-h);
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ─── Header (sticky, translucent) ─── */
 
 .app-header {
   display: flex;
-  align-items: baseline;
-  gap: 12px;
-  padding: 12px 20px;
-  background: var(--bg-elev);
-  border-bottom: 1px solid var(--border);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-4);
+  padding: 0 var(--s-6);
+  background: var(--bg-header);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-bottom: 1px solid var(--separator-thin);
+  position: relative;
+  z-index: 10;
 }
 
-.app-header h1 {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-bright);
+.header-text {
+  min-width: 0;
 }
 
-.subtitle {
-  font-size: 12px;
-  color: var(--text-dim);
+.header-title {
+  font-size: var(--t-title1);
+  font-weight: var(--w-semibold);
+  letter-spacing: var(--tr-title);
+  line-height: var(--lh-snug);
+  color: var(--text-primary);
 }
 
-.tabs {
-  display: flex;
-  gap: 2px;
-  padding: 0 12px;
-  background: var(--bg-elev);
-  border-bottom: 1px solid var(--border);
+.header-subtitle {
+  font-size: var(--t-caption);
+  color: var(--text-secondary);
+  letter-spacing: var(--tr-body);
+  line-height: var(--lh-snug);
+  margin-top: 2px;
 }
 
-.tab {
-  padding: 10px 16px;
-  background: transparent;
-  border: none;
-  color: var(--text-dim);
-  font-size: 13px;
-  font-family: var(--font-sans);
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: all 0.1s;
+/* ─── Status pill (header) ─── */
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-1) var(--s-3);
+  background: var(--bg-input);
+  border-radius: var(--r-pill);
+  font-size: var(--t-caption);
+  font-weight: var(--w-medium);
+  letter-spacing: var(--tr-body);
+  color: var(--text-primary);
+  flex-shrink: 0;
+  transition: background var(--t-normal) var(--ease-out);
 }
 
-.tab:hover {
-  color: var(--text);
+.status-pill::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  flex-shrink: 0;
 }
 
-.tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
+.status-pill.connected::before {
+  background: var(--accent-green);
+  box-shadow: 0 0 6px var(--accent-green);
 }
+
+.status-pill.offline::before {
+  background: var(--text-tertiary);
+}
+
+.status-pill.error::before {
+  background: var(--accent-red);
+  box-shadow: 0 0 6px var(--accent-red);
+}
+
+.status-pill.error {
+  color: var(--accent-red);
+}
+
+/* ─── Panel (content area) ─── */
 
 .panel {
-  flex: 1;
   overflow: auto;
-  padding: 20px;
+  padding: var(--s-6);
+  animation: panelFadeIn var(--t-normal) var(--ease-out);
 }
 
-/* ─── 通用 form ─── */
+@keyframes panelFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 
-.row {
+.panel-header {
+  margin-bottom: var(--s-5);
+}
+
+.panel-title {
+  font-size: var(--t-display);
+  font-weight: var(--w-bold);
+  letter-spacing: var(--tr-display);
+  line-height: var(--lh-tight);
+  color: var(--text-primary);
+}
+
+.panel-subtitle {
+  font-size: var(--t-callout);
+  color: var(--text-secondary);
+  margin-top: var(--s-1);
+  line-height: var(--lh-snug);
+}
+
+/* ─── Card (panel content block) ─── */
+
+.card {
+  background: var(--bg-card);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid var(--separator-thin);
+  border-radius: var(--r-lg);
+  padding: var(--s-5);
+  box-shadow: var(--shadow-1);
+  margin-bottom: var(--s-4);
+}
+
+.card-title {
+  font-size: var(--t-caption);
+  font-weight: var(--w-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tr-caps);
+  color: var(--text-secondary);
+  margin-bottom: var(--s-4);
+}
+
+/* ─── Form field (SF style) ─── */
+
+.field {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
+  flex-direction: column;
+  gap: var(--s-1);
+  margin-bottom: var(--s-4);
+}
+
+.field-label {
+  font-size: var(--t-caption);
+  font-weight: var(--w-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tr-caps);
+  color: var(--text-secondary);
+}
+
+.field-row {
+  display: flex;
+  gap: var(--s-3);
   flex-wrap: wrap;
 }
 
-.row label {
-  font-size: 12px;
-  color: var(--text-dim);
-  min-width: 60px;
-}
-
-.row .spacer {
-  margin-left: auto;
-}
-
-.row.toolbar {
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 16px;
-}
-
-.row.actions {
-  margin-top: 20px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
-}
-
-select, input[type="text"], input[type="number"] {
-  padding: 6px 10px;
-  background: var(--bg-elev-2);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font-family: var(--font-mono);
-  font-size: 13px;
+.field-row > .field {
+  flex: 1;
   min-width: 120px;
 }
 
-select:focus, input:focus {
+select, input[type="text"], input[type="number"] {
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 0 var(--s-3);
+  height: 28px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: none;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: var(--t-body);
+  letter-spacing: var(--tr-body);
   outline: none;
-  border-color: var(--accent);
+  transition: background var(--t-fast) var(--ease-out),
+              box-shadow var(--t-fast) var(--ease-out);
+}
+
+select {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='rgba(235,235,245,0.6)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right var(--s-3) center;
+  padding-right: var(--s-8);
+}
+
+select:focus, input:focus {
+  background: var(--bg-input-focus);
+  box-shadow: var(--shadow-focus);
 }
 
 select:disabled, input:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
+select option {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.hint {
+  font-size: var(--t-micro);
+  color: var(--text-tertiary);
+  letter-spacing: var(--tr-body);
+}
+
+/* ─── Button (SF style) ─── */
+
 button {
-  padding: 6px 14px;
-  background: var(--bg-elev-2);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-2);
+  padding: 0 var(--s-4);
+  height: 28px;
+  background: var(--bg-button);
+  color: var(--text-primary);
+  border: none;
+  border-radius: var(--r-sm);
   font-family: var(--font-sans);
+  font-size: var(--t-body);
+  font-weight: var(--w-medium);
+  letter-spacing: var(--tr-body);
   cursor: pointer;
-  transition: all 0.1s;
+  user-select: none;
+  transition: background var(--t-fast) var(--ease-out),
+              transform var(--t-fast) var(--ease-out);
 }
 
 button:hover:not(:disabled) {
-  background: var(--bg-elev);
-  border-color: var(--text-dim);
+  background: var(--bg-button-hover);
+}
+
+button:active:not(:disabled) {
+  transform: scale(0.97);
+  transition: transform 80ms var(--ease-out);
 }
 
 button:disabled {
@@ -181,74 +509,95 @@ button:disabled {
 }
 
 button.primary {
-  background: var(--accent);
-  color: white;
-  border-color: var(--accent);
+  background: var(--accent-blue);
+  color: #ffffff;
 }
 
 button.primary:hover:not(:disabled) {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
+  background: var(--accent-blue-hover);
 }
 
 button.danger {
-  background: var(--danger);
-  color: white;
-  border-color: var(--danger);
+  background: var(--accent-red);
+  color: #ffffff;
 }
 
 button.danger:hover:not(:disabled) {
-  background: var(--danger-hover);
-  border-color: var(--danger-hover);
+  background: #ff6961;
 }
 
-.hint {
-  font-size: 11px;
-  color: var(--text-dim);
+button.large {
+  height: 32px;
+  padding: 0 var(--s-5);
+  font-size: var(--t-body);
 }
 
-.status {
+.btn-row {
+  display: flex;
+  gap: var(--s-3);
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: var(--s-2);
+}
+
+/* ─── Inline status pill (form area, e.g. "已打开: ttyUSB0 @ 115200") ─── */
+
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-1) var(--s-3);
+  background: var(--bg-input);
+  border-radius: var(--r-pill);
   font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 2px 8px;
-  border-radius: 3px;
+  font-size: var(--t-caption);
+  color: var(--text-secondary);
+  letter-spacing: var(--tr-body);
 }
 
-.status.open {
-  background: rgba(76, 175, 80, 0.2);
-  color: var(--ok);
+.status-tag::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  flex-shrink: 0;
 }
 
-.status.closed {
-  background: var(--bg-elev-2);
-  color: var(--text-dim);
+.status-tag.open {
+  color: var(--accent-green);
+}
+
+.status-tag.open::before {
+  background: var(--accent-green);
+  box-shadow: 0 0 4px var(--accent-green);
+}
+
+.status-tag.closed::before {
+  background: var(--text-tertiary);
+}
+
+/* ─── Error / warn banners ─── */
+
+.error, .warn {
+  margin-top: var(--s-3);
+  padding: var(--s-3) var(--s-4);
+  border-radius: var(--r-md);
+  font-size: var(--t-caption);
+  line-height: var(--lh-normal);
+  border: 1px solid transparent;
 }
 
 .error {
-  margin-top: 12px;
-  padding: 8px 12px;
-  background: rgba(255, 85, 85, 0.15);
-  border: 1px solid var(--danger);
-  border-radius: 4px;
-  color: var(--danger);
-  font-size: 12px;
+  background: rgba(255, 69, 58, 0.12);
+  border-color: rgba(255, 69, 58, 0.3);
+  color: var(--accent-red);
 }
 
 .warn {
-  margin-bottom: 16px;
-  padding: 10px 14px;
-  background: rgba(255, 170, 0, 0.1);
-  border: 1px solid var(--warn);
-  border-radius: 4px;
-  color: var(--warn);
-  font-size: 12px;
-}
-
-.count {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--text-dim);
-  font-family: var(--font-mono);
+  background: rgba(255, 159, 10, 0.12);
+  border-color: rgba(255, 159, 10, 0.3);
+  color: var(--accent-orange);
 }
 
 /* ─── AT Console ─── */
@@ -257,76 +606,101 @@ button.danger:hover:not(:disabled) {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
+  gap: var(--s-3);
 }
 
 .cmd-input {
   flex: 1;
-  font-size: 14px;
+  font-size: var(--t-callout);
+  height: 32px;
+  font-family: var(--font-mono);
 }
 
 .suggestions {
   display: flex;
-  gap: 4px;
+  gap: var(--s-2);
   flex-wrap: wrap;
-  margin-bottom: 12px;
+  margin-bottom: var(--s-1);
 }
 
 .suggestion {
-  padding: 2px 8px;
-  font-size: 11px;
+  padding: 0 var(--s-3);
+  height: 24px;
+  font-size: var(--t-micro);
   font-family: var(--font-mono);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  border-radius: var(--r-pill);
+  letter-spacing: var(--tr-body);
+}
+
+.suggestion:hover:not(:disabled) {
+  background: var(--bg-input-focus);
+  color: var(--text-primary);
 }
 
 .log {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--separator-thin);
+  border-radius: var(--r-md);
+  padding: var(--s-3);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-caption);
+  line-height: var(--lh-relaxed);
 }
 
 .log-entry {
   display: flex;
-  gap: 8px;
-  padding: 2px 4px;
+  gap: var(--s-3);
+  padding: var(--s-1) var(--s-2);
   align-items: baseline;
+  border-radius: var(--r-sm);
+  transition: background var(--t-fast) var(--ease-out);
 }
 
 .log-entry:hover {
-  background: var(--bg-elev-2);
+  background: var(--bg-button);
 }
 
 .log-entry .ts {
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: var(--t-micro);
+  font-variant-numeric: tabular-nums;
 }
 
 .log-entry .dir {
   flex-shrink: 0;
-  font-weight: bold;
-  width: 12px;
+  font-weight: var(--w-bold);
+  width: 14px;
+  font-family: var(--font-mono);
 }
 
-.log-tx .dir { color: var(--tx); }
-.log-rx .dir { color: var(--rx); }
+.log-tx .dir { color: var(--serial-tx); }
+.log-rx .dir { color: var(--serial-rx); }
 
 .log-entry .ascii {
   flex: 0 0 auto;
-  color: var(--text-bright);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  word-break: break-all;
 }
 
 .log-entry .hex {
-  color: var(--text-dim);
-  font-size: 11px;
+  color: var(--text-tertiary);
+  font-size: var(--t-micro);
+  font-family: var(--font-mono);
 }
 
 .log-entry .parsed {
-  color: var(--ok);
-  font-size: 11px;
+  color: var(--serial-parsed);
+  font-size: var(--t-micro);
+  font-family: var(--font-mono);
+  margin-left: var(--s-2);
 }
 
 /* ─── HEX View ─── */
@@ -335,154 +709,326 @@ button.danger:hover:not(:disabled) {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
+  gap: var(--s-3);
 }
 
 .seg {
-  display: flex;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  overflow: hidden;
+  display: inline-flex;
+  background: var(--bg-input);
+  border-radius: var(--r-md);
+  padding: 2px;
+  gap: 2px;
 }
 
 .seg-btn {
+  background: transparent;
   border: none;
-  border-radius: 0;
-  background: var(--bg-elev-2);
-  padding: 6px 12px;
-  font-size: 11px;
+  border-radius: 7px;
+  padding: 0 var(--s-3);
+  height: 22px;
+  font-size: var(--t-micro);
+  font-weight: var(--w-medium);
   font-family: var(--font-mono);
+  color: var(--text-secondary);
+  letter-spacing: var(--tr-body);
+  text-transform: uppercase;
 }
 
-.seg-btn:not(:last-child) {
-  border-right: 1px solid var(--border);
+.seg-btn:hover:not(.active) {
+  color: var(--text-primary);
 }
 
 .seg-btn.active {
-  background: var(--accent);
-  color: white;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-1);
+}
+
+.seg-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  font-size: var(--t-callout);
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 32px;
+  height: 18px;
+  background: var(--bg-input);
+  border-radius: var(--r-pill);
+  position: relative;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease-out);
+  margin: 0;
+}
+
+.toggle input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  background: var(--text-secondary);
+  border-radius: 50%;
+  transition: transform var(--t-fast) var(--ease-out),
+              background var(--t-fast) var(--ease-out);
+}
+
+.toggle input[type="checkbox"]:checked {
+  background: var(--accent-green);
+}
+
+.toggle input[type="checkbox"]:checked::after {
+  transform: translateX(14px);
+  background: #ffffff;
+}
+
+.count {
+  margin-left: auto;
+  font-size: var(--t-micro);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
 }
 
 .hex-log {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--separator-thin);
+  border-radius: var(--r-md);
+  padding: var(--s-3);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--t-caption);
+  line-height: var(--lh-relaxed);
 }
 
 .hex-log .empty {
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   text-align: center;
-  padding: 40px;
+  padding: var(--s-10) 0;
   font-style: italic;
+  font-size: var(--t-callout);
 }
 
 .hex-row {
   display: flex;
-  gap: 16px;
-  padding: 2px 4px;
-  border-bottom: 1px solid transparent;
+  gap: var(--s-4);
+  padding: var(--s-1) var(--s-2);
+  border-radius: var(--r-sm);
+  transition: background var(--t-fast) var(--ease-out);
+  align-items: baseline;
 }
 
 .hex-row:hover {
-  background: var(--bg-elev-2);
+  background: var(--bg-button);
 }
 
 .hex-row .ts {
-  color: var(--text-dim);
-  font-size: 10px;
+  color: var(--text-tertiary);
+  font-size: var(--t-micro);
   flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 .hex-row .hex {
-  color: var(--accent);
+  color: var(--accent-blue);
   font-family: var(--font-mono);
+  font-size: var(--t-caption);
 }
 
 .hex-row .ascii {
-  color: var(--text-bright);
+  color: var(--text-primary);
   font-family: var(--font-mono);
+  font-size: var(--t-caption);
 }
 
 /* ─── Protocol Viewer ─── */
 
 .protocol-detail {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 20px;
+  background: var(--bg-card);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid var(--separator-thin);
+  border-radius: var(--r-lg);
+  padding: var(--s-5);
+  box-shadow: var(--shadow-1);
 }
 
 .protocol-detail h2 {
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 16px;
-  color: var(--text-bright);
+  font-size: var(--t-title1);
+  font-weight: var(--w-semibold);
+  letter-spacing: var(--tr-title);
+  line-height: var(--lh-snug);
+  margin-bottom: var(--s-2);
+  color: var(--text-primary);
 }
 
 .protocol-detail h3 {
-  font-size: 13px;
-  font-weight: 600;
-  margin-top: 20px;
-  margin-bottom: 8px;
-  color: var(--accent);
+  font-size: var(--t-caption);
+  font-weight: var(--w-semibold);
+  margin-top: var(--s-5);
+  margin-bottom: var(--s-3);
+  color: var(--text-secondary);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tr-caps);
 }
 
 dl.meta {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 4px 16px;
-  font-size: 12px;
+  gap: var(--s-2) var(--s-5);
+  font-size: var(--t-callout);
   font-family: var(--font-mono);
+  line-height: var(--lh-normal);
 }
 
 dl.meta dt {
-  color: var(--text-dim);
+  color: var(--text-secondary);
+  font-weight: var(--w-regular);
 }
 
 dl.meta dd {
-  color: var(--text);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
 }
 
-dl.meta code, code {
-  background: var(--bg-elev-2);
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 11px;
-  color: var(--accent);
+code {
+  background: var(--bg-input);
+  padding: 1px var(--s-2);
+  border-radius: var(--r-sm);
+  font-size: var(--t-caption);
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
 }
 
 code.regex {
-  color: var(--warn);
+  color: var(--accent-orange);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--t-caption);
   font-family: var(--font-mono);
-  margin-top: 4px;
+  margin-top: var(--s-2);
+  border-radius: var(--r-md);
+  overflow: hidden;
 }
 
 table th, table td {
   text-align: left;
-  padding: 6px 10px;
-  border-bottom: 1px solid var(--border);
+  padding: var(--s-2) var(--s-3);
+  border-bottom: 1px solid var(--separator-thin);
 }
 
 table th {
-  color: var(--text-dim);
-  font-weight: 600;
+  color: var(--text-secondary);
+  font-weight: var(--w-semibold);
   text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.5px;
+  font-size: var(--t-micro);
+  letter-spacing: var(--tr-caps);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+table tr:last-child td {
+  border-bottom: none;
+}
+
+table tr {
+  transition: background var(--t-fast) var(--ease-out);
 }
 
 table tr:hover td {
-  background: var(--bg-elev-2);
+  background: var(--bg-button);
+}
+
+/* ─── Status bar (footer, 28px) ─── */
+
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: 0 var(--s-6);
+  background: var(--bg-statusbar);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-top: 1px solid var(--separator-thin);
+  font-size: var(--t-micro);
+  color: var(--text-secondary);
+  letter-spacing: var(--tr-body);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  position: relative;
+  z-index: 10;
+}
+
+.status-bar .sep {
+  color: var(--text-quaternary);
+}
+
+.status-bar .spacer {
+  flex: 1;
+}
+
+.status-bar .indicator {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.status-bar .indicator.connected { background: var(--accent-green); }
+.status-bar .indicator.offline { background: var(--text-tertiary); }
+.status-bar .indicator.error { background: var(--accent-red); }
+
+/* ─── Reduced motion (accessibility) ─── */
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+  .panel { animation: none; }
+  button:active:not(:disabled),
+  .nav-item:active { transform: none; }
+}
+
+/* ─── Reduced transparency (accessibility) ─── */
+
+@media (prefers-reduced-transparency: reduce) {
+  .sidebar,
+  .app-header,
+  .status-bar,
+  .card,
+  .protocol-detail {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: var(--bg-elevated);
+  }
+}
+
+/* ─── Light mode (Phase 2 — token 留好, Phase 1 不实现完整) ─── */
+
+@media (prefers-color-scheme: light) {
+  /* Phase 2 加: 浅色模式色板, Phase 1 先不实现, 用户系统 dark 优先 */
+  /* 临时让 light mode 也走 dark tokens, 避免视觉跳变 */
+  html, body, #app {
+    background: var(--bg-base);
+    color: var(--text-primary);
+  }
 }

--- a/packages/soft-dtu/webview/tsconfig.json
+++ b/packages/soft-dtu/webview/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  },
+  "include": ["src/**/*", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/soft-dtu/webview/tsconfig.json
+++ b/packages/soft-dtu/webview/tsconfig.json
@@ -16,6 +16,8 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": true,
     "paths": {

--- a/packages/soft-dtu/webview/vite.config.ts
+++ b/packages/soft-dtu/webview/vite.config.ts
@@ -1,0 +1,45 @@
+/**
+ * Vite 配置 — 软 DTU WebView
+ *
+ * Phase 1 dev 工作流：
+ *   1. `deno task dev` 启动软 DTU 后端（HTTP serve on 127.0.0.1:8080，暴露 /api/* 包装 bindings）
+ *   2. `npm run dev`（在这个目录）启动 Vite dev server on 127.0.0.1:5173
+ *   3. Vite 把 /api/* 代理到后端 (8080)
+ *   4. 浏览器开 http://127.0.0.1:5173
+ *
+ * Phase 2 切 Deno Desktop bindings SDK 时，bindings.ts 切到 window.bindings.*，
+ * Vite proxy 可以删掉（WebView 直接 IPC 调 Deno runtime）。
+ */
+
+import { defineConfig } from "vite";
+import preact from "@preact/preset-vite";
+
+export default defineConfig({
+  plugins: [preact()],
+
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      // 软 DTU 后端 HTTP serve 端点
+      "/api": {
+        target: process.env.VITE_API_TARGET ?? "http://127.0.0.1:8080",
+        changeOrigin: true,
+      },
+    },
+  },
+
+  build: {
+    outDir: "dist",
+    sourcemap: true,
+    target: "es2022",
+  },
+
+  // 用 'preact' 别名替换 'react'，省体积
+  resolve: {
+    alias: {
+      react: "preact/compat",
+      "react-dom": "preact/compat",
+    },
+  },
+});

--- a/src/dtus/base.ts
+++ b/src/dtus/base.ts
@@ -78,6 +78,21 @@ export abstract class Dtu {
   /** 暂停传输模式标志（initialize 期间置 true） */
   protected pause = false
 
+  /**
+   * ATInstruct ack 回调表（emit-with-ack 新协议用, fix AT timeout 2026-07-14）
+   *
+   * server 端 `OprateDTU` 现在用 `getApp().in(mountNode).timeout(10_000).emit('DTUoprate', Query, (err, ack) => resolve(ack))`
+   * 走 socket.io 4.x 原生 ack 机制,期望 Node 端在拿到 AT 响应后调 ack(result) 第三参数。
+   *
+   * 老协议 `getIOClient().emit('dtuopratesuccess' as any, query.events, result)` 走
+   * server 端 `node.socket.controller.ts:dtuOprateSuccess` 转发到内部 EventEmitter
+   * 触发 `event.once(Query.events, ...)` — 仍保留做向后兼容。
+   *
+   * Map key = `query.events` (server 端生成的唯一 event 名, 'QueryAT' + Date.now() + mac 形式)
+   * 12s 清理 timer 略长于 server 10s timeout, 防 AT 永远不返回导致 map 累积。
+   */
+  private atAckCallbacks: Map<string, (result: Partial<ApolloMongoResult>) => void> = new Map()
+
   // ======================== 状态机字段 (PR #6 落地, RFC 002 §12) ========================
 
   /** 当前 DtuState（PR #6 落地） */
@@ -363,6 +378,40 @@ export abstract class Dtu {
   }
 
   /**
+   * 注册 AT 指令的 ack 回调（emit-with-ack 新协议, fix AT timeout 2026-07-14）
+   *
+   * 由 TcpServer.bus() 在收到 server 'DTUoprate' 事件 + ack 回调时调用,
+   * 后续 atParse() 拿到 AT 响应后会调 resolveAck() 触发 ack 通知 server。
+   *
+   * 12s 清理 timer: 略长于 server 端 10s timeout, 防 AT 永远不返回 (设备掉线 / 协议错)
+   * 导致 map 累积;即使 ack 永不调用, server 端 setTimeout 兜底也会先 resolve 出错结果。
+   */
+  public registerAck(
+    events: string,
+    ack: (result: Partial<ApolloMongoResult>) => void
+  ): void {
+    // lazy init: 测试用 Object.create() 跳构造器, atAckCallbacks 字段未初始化
+    this.atAckCallbacks ??= new Map()
+    this.atAckCallbacks.set(events, ack)
+    setTimeout(() => {
+      this.atAckCallbacks.delete(events)
+    }, 12_000)
+  }
+
+  /**
+   * 触发 AT ack 回调（atParse 拿到结果时调, 紧跟 dtuopratesuccess 老事件 emit 之后）
+   */
+  protected resolveAck(events: string, result: Partial<ApolloMongoResult>): void {
+    // lazy init: 同 registerAck, 测试 Object.create 跳构造器场景
+    this.atAckCallbacks ??= new Map()
+    const ack = this.atAckCallbacks.get(events)
+    if (ack) {
+      this.atAckCallbacks.delete(events)
+      ack(result)
+    }
+  }
+
+  /**
    * 通用：socket close 时通知 server
    * （RFC 002 §3.4 字面方法，子类可重写；默认 1:1 抄老 client.ts bindSocket close 行为）
    */
@@ -535,6 +584,14 @@ export abstract class Dtu {
    * 关键不变量：
    *   - 解析成功且 msg 为空（如 IOTEN=off）→ 触发 run() 重查全部属性
    *   - 解析失败 → ok=0 + "挂载设备响应超时" 提示
+   *
+   * 协议双轨（fix AT timeout 2026-07-14）:
+   *   1. 老协议 `getIOClient().emit('dtuopratesuccess', events, result)`
+   *      → server 端 `node.socket.controller.ts:dtuOprateSuccess` 转发到
+   *      内部 EventEmitter 触发 `event.once(events, ...)` 路径
+   *   2. 新协议 `resolveAck(events, result)` 触发 server emit-with-ack
+   *      第三参数, 这是 server 端首选路径 (走 timeout(10_000) ack)
+   *   两条都触发则 server 端 Promise resolve 多次都是 no-op
    */
   protected atParse(query: DTUoprate, res: socketResult): void {
     const { buffer } = res
@@ -551,6 +608,9 @@ export abstract class Dtu {
       upserted: buffer
     }
     console.log({ Query: query, result, res })
+    // 老协议: 向后兼容, 老 midway Node / uart-node 走过的路径
     getIOClient().emit('dtuopratesuccess' as any, query.events, result)
+    // 新协议: server emit-with-ack 第三参数, 修 10s timeout
+    this.resolveAck(query.events, result)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import config, { IO_CONFIG } from "./config"
-import { registerConfig, queryObjectServer, instructQuery, DTUoprate } from "uart"
+import { type registerConfig, type queryObjectServer, type instructQuery, type DTUoprate, type ApolloMongoResult } from "uart"
 import IOClient from "./IO"
 import TcpServer from "./server/tcp-server"
 import { nodeInfo } from "./services/dtu-info"
@@ -39,8 +39,12 @@ IOClient
     })
 
     // 发送终端设备AT指令
-    .on(config.EVENT_SERVER.DTUoprate, async (Query: DTUoprate) => {
-        tcpServer.bus("ATInstruct", Query as DTUoprate)
+    // 2026-07-14: server 端 OprateDTU 走 emit-with-ack 新协议,期望 Node 端
+    // 在 AT 响应后调 ack(result) 第三参数,否则 server 10s timeout 兜底报
+    // "Node 端在 10000ms 内未响应 (operation has timed out)".
+    // 老协议 `dtuopratesuccess` 事件仍保留 (server event.once 路径) 做向后兼容
+    .on(config.EVENT_SERVER.DTUoprate, async (Query: DTUoprate, ack?: (result: Partial<ApolloMongoResult>) => void) => {
+        tcpServer.bus("ATInstruct", Query as DTUoprate, ack)
     })
 
     // 服务器要求发送查询节点运行状态

--- a/src/server/tcp-server.ts
+++ b/src/server/tcp-server.ts
@@ -19,7 +19,7 @@
 
 import net, { Server, Socket } from 'net'
 import config from '../config'
-import { queryObjectServer, instructQuery, DTUoprate, eventType, registerConfig } from 'uart'
+import { type queryObjectServer, type instructQuery, type DTUoprate, eventType, type registerConfig, type ApolloMongoResult } from 'uart'
 import { getIOClient } from '../services/io-client'
 import { Dtu } from '../dtus/base'
 import {
@@ -124,12 +124,29 @@ export class TcpServer {
   /**
    * 给 server 下行指令（query / AT / operate）派发
    * 行为跟老 src/TcpServer.ts:145-151 Bus() 1:1
+   *
+   * @param ack 可选 — 仅 ATInstruct 用, server 端 emit-with-ack 第三参数
+   *            透传给 Dtu.registerAck(), 后续 atParse() 拿 AT 响应后
+   *            调 ack(result) 通知 server, 修 10s timeout (2026-07-14)
    */
-  bus<T extends queryObjectServer | instructQuery | DTUoprate>(eventType: eventType, query: T): void {
+  bus<T extends queryObjectServer | instructQuery | DTUoprate>(
+    eventType: eventType,
+    query: T,
+    ack?: (result: Partial<ApolloMongoResult>) => void
+  ): void {
     const dtu = this.macSocketMaps.get(query.DevMac)
     if (dtu && dtu.socketsb) {
       query.eventType = eventType
       dtu.saveCache(query)
+      // ATInstruct 走新协议 emit-with-ack: 把 ack 挂在 dtu 上, 后续 atParse 触发
+      if (eventType === 'ATInstruct' && ack) {
+        dtu.registerAck(query.events, ack)
+      }
+    } else {
+      // 设备不在线 / 未注册 — 立即回 ack (不阻塞 server 10s 超时)
+      if (eventType === 'ATInstruct' && ack) {
+        ack({ ok: 0, msg: '设备不在线或未注册到当前节点' })
+      }
     }
   }
 


### PR DESCRIPTION
# 软 DTU 第一波 + UartNode v4 docs 同步

## Commit 清单 (6 commits)

### docs sync v4 (4 commits)
1. docs(AGENTS): sync with v4 refactor (PR #1-#12)
2. docs(README): sync with v4 refactor + add test section
3. docs(architecture): sync source-map + data-flow with v4 paths
4. docs(changelogs): record 2026-07-14 docs sync

### soft-dtu skeleton (1 commit)
5. feat(soft-dtu): scaffold Deno Desktop skeleton (Phase 1 Day 1)
- 13 个新文件 (deno.json, main.ts, AGENTS.md, README.md, src/protocol/*, src/transport/*, src/bindings/*)
- 8 条 AT 指令 跟 UartNode 端 cellular.ts:queryAT 1:1 兼容
- 协议定义走 HTTP API 从 server 拉
- src/transport/socketio.ts 留本地未 commit（已废弃 stub）

### soft-dtu webview framework (1 commit)
6. feat(soft-dtu): webview framework + HTTP API stub (Phase 1 Day 4-5)
- 14 个新 webview/ 文件（Vite + Preact + TypeScript）
- 4 个面板：串口配置 / AT 指令控制台 / HEX-ASCII 实时视图 / 协议定义浏览器
- HTTP API stub (src/server/http-api.ts)
- dev 工作流：Deno 后端 (8080) + Vite dev (5173)
- server-api-contract.md 字段契约

## 设计原则
- 数据通道：软 DTU 跟普通硬件 DTU 完全对等
- 元数据通道：HTTP API 从 server 拉（不鉴权，dev/内网）
- 不连 Socket.IO
- 协议让用户手动选

## 测试
- UartNode: bun test 8/8 unit pass
- midwayuartserver: 15/15 test pass
- 软 DTU/WebView: 0 test (Phase 2)

## 跨项目
- server sibling: agent-ae682922673b (midwayuartserver)
- 软 DTU 仓库: wgcairui/uart-node